### PR TITLE
Linting & typedef fixes

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,7 +2,8 @@
   "ignoreFiles": [
     "./node_modules/**/*",
     "./src/styles/vendor/**/*",
-    "./build/**/*"
+    "./build/**/*",
+    "**/*.js"
   ],
   "extends": "stylelint-config-standard",
   "rules": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "morgan": "^1.10.0",
     "pouchdb": "^7.2.1",
     "pouchdb-adapter-memory": "^7.2.1",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2",

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -1,9 +1,24 @@
 import EventEmitter from 'eventemitter3';
-import { styleFactory } from '../../../model/style';
-import { CytoscapeSyncher } from '../../../model/cytoscape-syncher';
-import Cytoscape from 'cytoscape';
+import { styleFactory, LinearColorStyleValue, LinearNumberStyleValue } from '../../../model/style'; // eslint-disable-line
+import { CytoscapeSyncher } from '../../../model/cytoscape-syncher'; // eslint-disable-line
+import Cytoscape from 'cytoscape'; // eslint-disable-line
+import Color from 'color'; // eslint-disable-line
 
+/**
+ * The network editor controller contains all high-level model operations that the network
+ * editor view can perform.
+ * 
+ * @property {Cytoscape} cy The graph instance
+ * @property {CytoscapeSyncher} cySyncher The syncher that corresponds to the graph instance
+ * @property {EventEmitter} bus The event bus that the controller emits on after every operation
+ */
 export class NetworkEditorController {
+  /**
+   * Create an instance of the controller
+   * @param {Cytoscape} cy The graph instance (model)
+   * @param {CytoscapeSyncher} cySyncher The syncher that corresponds to the Cytoscape instance
+   * @param {EventEmitter} bus The event bus that the controller emits on after every operation
+   */
   constructor(cy, cySyncher, bus){
     /** @type Cytoscape */
     this.cy = cy;
@@ -17,6 +32,9 @@ export class NetworkEditorController {
     this.drawModeEnabled = false;
   }
 
+  /**
+   * Add a new node to the graph
+   */
   addNode() {
     function randomArg(... args) {
       return args[Math.floor(Math.random() * args.length)];
@@ -33,6 +51,10 @@ export class NetworkEditorController {
     this.bus.emit('addNode', node);
   }
 
+  /**
+   * Toggle whether draw mode is enabled
+   * @param {Boolean} [bool] A boolean override (i.e. force enable on true, force disable on false)
+   */
   toggleDrawMode(bool = !this.drawModeEnabled){
     if( bool ){
       this.eh.enableDrawMode();
@@ -44,56 +66,100 @@ export class NetworkEditorController {
 
     this.drawModeEnabled = bool;
 
+    /**
+     * toggleDrawMode event
+     * @event NetworkEditorController#toggleDrawMode
+     * @argument {Boolean} bool Whether draw mode has been enabled (true) or disabled (false)
+     */
     this.bus.emit('toggleDrawMode', bool);
   }
 
+  /**
+   * Enable draw mode
+   */
   enableDrawMode(){
     return this.toggleDrawMode(true);
   }
 
+  /**
+   * Disable draw mode
+   */
   disableDrawMode(){
     this.toggleDrawMode(false);
   }
 
+  /**
+   * Delete the selected (i.e. :selected) elements in the graph
+   */
   deletedSelectedElements(){
     const deletedEls = this.cy.$(':selected').remove();
 
     this.bus.emit('deletedSelectedElements', deletedEls);
   }
 
+  /**
+   * Get the list of data attributes that exist on the nodes
+   * @returns {Array<String>} An array of public attribute names
+   */
   getPublicAttributes() {
     const attrNames = new Set();
     const nodes = this.cy.nodes();
+    
     nodes.forEach(n => {
-      const attrs = Object.keys(n.json().data);
+      const attrs = Object.keys(n.data());
       attrs.forEach(a => {
-        attrNames.add(a)
+        attrNames.add(a);
       });
     });
+
     return Array.from(attrNames);
   }
 
+  /**
+   * Set the color of all nodes to a single color
+   * @param {(Color|String)} color The color to set
+   */
   setNodeColor(color){
     console.log("setNodeColor");
     this.cySyncher.setStyle('node', 'background-color', styleFactory.color(color));
   }
 
+  /**
+   * Set the color of all nodes to a mapping
+   * @param {String} attribute The data attribute to map
+   * @param {LinearColorStyleValue} value The style mapping struct value to use as the mapping
+   */
   setNodeColorMapping(attribute, value) {
     console.log("setNodeColorMapping");
     const {hasVal, min, max} = this._minMax(attribute);
+    
     if(!hasVal)
       return;
 
     const style = styleFactory.linearColor(attribute,  min,  max, value.styleValue1, value.styleValue2);
+    
     this.cySyncher.setStyle('node', 'background-color', style);
+
+    this.bus.emit('setNodeColorMapping', attribute, value);
   }
 
+  /**
+   * Set the node size to a fixed value
+   * @param {Number} size The new size of the nodes
+   */
   setNodeSize(size) {
     console.log("setNodeSize");
     this.cySyncher.setStyle('node', 'width',  styleFactory.number(size));
     this.cySyncher.setStyle('node', 'height', styleFactory.number(size));
+
+    this.bus.emit('setNodeSize', size);
   }
 
+  /**
+   * Set the node sizes to a linear attribute mapping
+   * @param {String} attribute The data attribute to use as mapping input
+   * @param {LinearNumberStyleValue} value The number style struct value to use
+   */
   setNodeSizeMapping(attribute, value) {
     console.log("setNodeSizeGradient");
     const {hasVal, min, max} = this._minMax(attribute);
@@ -101,12 +167,16 @@ export class NetworkEditorController {
       return;
 
     const style = styleFactory.linearNumber(attribute,  min,  max, value.styleValue1, value.styleValue2);
+    
     this.cySyncher.setStyle('node', 'width',  style);
     this.cySyncher.setStyle('node', 'height', style);
+
+    this.bus.emit('setNodeSizeMapping', attribute, value);
   }
    
   /**
    * Returns the min and max values of a numeric attribute.
+   * @private
    */
   _minMax(attribute, eles) {
     eles = eles || this.cy.elements();

--- a/src/client/components/network-editor/style-panel.js
+++ b/src/client/components/network-editor/style-panel.js
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
 import EventEmitterProxy from '../../../model/event-emitter-proxy';
 import StylePickerButton from '../style/style-picker-button';
-import { ColorSwatches, ColorGradients } from '../style/color-swatches'
-import { SizeSlider, SizeGradients } from '../style/size-slider'
+import { ColorSwatches, ColorGradients } from '../style/color-swatches';
+import { SizeSlider, SizeGradients } from '../style/size-slider';
+import PropTypes from 'prop-types';
+import { NetworkEditorController } from './controller';
 
 export class StylePanel extends Component {
   constructor(props){
@@ -72,5 +74,9 @@ export class StylePanel extends Component {
     );
   }
 }
+
+StylePanel.propTypes = {
+  controller: PropTypes.instanceOf(NetworkEditorController)
+};
 
 export default StylePanel;

--- a/src/client/components/network-editor/tool-panel.js
+++ b/src/client/components/network-editor/tool-panel.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import EventEmitterProxy from '../../../model/event-emitter-proxy';
+import PropTypes from 'prop-types';
+import { NetworkEditorController } from './controller';
 
 export class ToolPanel extends Component {
   constructor(props){
@@ -48,5 +50,9 @@ export class ToolPanel extends Component {
     );
   }
 }
+
+ToolPanel.propTypes = {
+  controller: PropTypes.instanceOf(NetworkEditorController)
+};
 
 export default ToolPanel;

--- a/src/client/components/style/color-swatches.js
+++ b/src/client/components/style/color-swatches.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import colorConvert from 'color-convert';
 import classNames from 'classnames';
 import Color from 'color';
+import PropTypes from 'prop-types';
 
 
 // TODO improve defaults
@@ -25,13 +26,13 @@ const defaults = {
 };
 
 // TODO, divergent gradients not properly supported yet
-const colorBrewerDivergent = [
-  {start:[202,0,32],   mid:[247,247,247], end:[5,113,176]}, // RdBu
-  {start:[230,97,1],   mid:[247,247,247], end:[94,60,153]}, // PuOr
-  {start:[123,50,148], mid:[247,247,247], end:[0,136,55]},  // PRGn
-  {start:[166,97,26],  mid:[245,245,245], end:[1,133,113]}, // BrBG
-  {start:[215,25,28],  mid:[255,255,191], end:[26,150,65]}, // RdLyGn
-]
+// const colorBrewerDivergent = [
+//   {start:[202,0,32],   mid:[247,247,247], end:[5,113,176]}, // RdBu
+//   {start:[230,97,1],   mid:[247,247,247], end:[94,60,153]}, // PuOr
+//   {start:[123,50,148], mid:[247,247,247], end:[0,136,55]},  // PRGn
+//   {start:[166,97,26],  mid:[245,245,245], end:[1,133,113]}, // BrBG
+//   {start:[215,25,28],  mid:[255,255,191], end:[26,150,65]}, // RdLyGn
+// ];
 
 function rgbCss(c) {
   return Color(c).rgb().string();
@@ -39,17 +40,23 @@ function rgbCss(c) {
 
 
 export function ColorSwatch(props) {
-    return (
-      <div 
-        className={classNames({ 
-          'color-swatches-color': true, 
-          'color-swatches-color-selected': props.selected
-        })}
-        onClick = {() => props.onSelect(props.color)}
-        style={{ backgroundColor: rgbCss(props.color) }} >
-      </div>
-    );
+  return (
+    <div 
+      className={classNames({ 
+        'color-swatches-color': true, 
+        'color-swatches-color-selected': props.selected
+      })}
+      onClick = {() => props.onSelect(props.color)}
+      style={{ backgroundColor: rgbCss(props.color) }} >
+    </div>
+  );
 }
+
+ColorSwatch.propTypes = {
+  onSelect: PropTypes.func,
+  selected: PropTypes.any,
+  color: PropTypes.any
+};
 
 
 export class ColorSwatches extends Component {
@@ -90,11 +97,12 @@ export class ColorSwatches extends Component {
 
     return (
       <div className="color-swatches">
-        { groups.map(group => 
-          <div className="color-swatches-hue">
-            { group.colors.map(c => 
+        { groups.map((group, i) => 
+          <div key={`group-${i}`} className="color-swatches-hue">
+            { group.colors.map((c, i) => 
                 <ColorSwatch 
-                  color={c} 
+                  color={c}
+                  key={`swatch-${i}`}
                   selected={_.isEqual(this.props.selected, c)} 
                   onSelect={this.props.onSelect} />
             )}
@@ -104,6 +112,11 @@ export class ColorSwatches extends Component {
     );
   }
 }
+
+ColorSwatches.propTypes = {
+  selected: PropTypes.any,
+  onSelect: PropTypes.func
+};
 
 
 export function ColorGradient(props) {
@@ -123,6 +136,16 @@ export function ColorGradient(props) {
     </div>
   );
 }
+
+ColorGradient.propTypes = {
+  value: PropTypes.instanceOf({
+    styleValue1: PropTypes.any,
+    styleValue2: PropTypes.any,
+    styleValue3: PropTypes.any
+  }),
+  onSelect: PropTypes.func,
+  selected: PropTypes.any
+};
 
 
 export function ColorGradients(props) {
@@ -148,9 +171,10 @@ export function ColorGradients(props) {
     <div className="color-gradients">
       {/* <div>Linear</div> */}
       <div>
-      { linearGradients.map(value => 
+      { linearGradients.map((value, i) => 
           <ColorGradient 
             value={value} 
+            key={`gradient-${i}`}
             selected={_.isMatch(props.selected, value)}
             onSelect={props.onSelect} />
       )}
@@ -168,3 +192,12 @@ export function ColorGradients(props) {
   );
 }
 
+ColorGradients.propTypes = {
+  minSaturation: PropTypes.number,
+  maxSaturation: PropTypes.number,
+  minLightness: PropTypes.number,
+  maxLightness: PropTypes.number,
+  onSelect: PropTypes.func,
+  hues: PropTypes.arrayOf(PropTypes.number),
+  selected: PropTypes.any
+};

--- a/src/client/components/style/size-slider.js
+++ b/src/client/components/style/size-slider.js
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
+import React from 'react';
 import _ from 'lodash';
 import classNames from 'classnames';
-
+import PropTypes from 'prop-types';
 
 export function SizeSlider(props) {
-  const debouncedChange = _.debounce(value => props.onSelect(value), 150)
+  const debouncedChange = _.debounce(value => props.onSelect(value), 150);
   return (
     <input 
       type="range" 
@@ -15,12 +15,17 @@ export function SizeSlider(props) {
   );
 }
 
+SizeSlider.propTypes = {
+  size: PropTypes.number,
+  onSelect: PropTypes.func
+};
+
 
 export function SizeGradients(props) {
   // TODO this code is pretty hackey
   const sizes = [20, 25, 30, 35, 40];
   const circles = sizes.map(size => (
-    <div className="size-swatches-circle" style={{ width:size, height:size }}></div>
+    <div key="size-swatches-circle-{size}" className="size-swatches-circle" style={{ width:size, height:size }}></div>
   ));
   const reversed = circles.slice().reverse();
 
@@ -45,3 +50,8 @@ export function SizeGradients(props) {
     </div>
   );
 }
+
+SizeGradients.propTypes = {
+  onSelect: PropTypes.func,
+  selected: PropTypes.any
+};

--- a/src/client/components/style/style-picker-button.js
+++ b/src/client/components/style/style-picker-button.js
@@ -1,7 +1,14 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Tippy from '@tippy.js/react';
 import StylePicker from '../style/style-picker';
+import PropTypes from 'prop-types';
 
+/**
+ * A style picker button
+ * @param {Object} props React props
+ * @param {String} props.buttonIcon The CSS icon class of the icon in the button
+ * @param {String} props.title Title of the button (shown in tooltip)
+ */
 export function StylePickerButton(props)  {
   const ref = React.createRef();
   const tooltip = props.title;
@@ -22,5 +29,10 @@ export function StylePickerButton(props)  {
     </Tippy>
   );
 }
+
+StylePickerButton.propTypes = {
+  buttonIcon: PropTypes.string,
+  title: PropTypes.string
+};
 
 export default StylePickerButton;

--- a/src/client/components/style/style-picker.js
+++ b/src/client/components/style/style-picker.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import Select from 'react-select';
 import { MAPPING } from '../../../model/style';
 import _ from 'lodash';
+import { NetworkEditorController } from '../network-editor/controller';
+import PropTypes from 'prop-types';
 
 export class StylePicker extends Component { 
 
@@ -140,5 +142,18 @@ export class StylePicker extends Component {
   }
 
 }
+
+StylePicker.propTypes = {
+  controller: PropTypes.instanceOf(NetworkEditorController),
+  renderMapping: PropTypes.func,
+  renderValue: PropTypes.func,
+  selector: PropTypes.string,
+  property: PropTypes.string,
+  onValueSet: PropTypes.func,
+  onMappingSet: PropTypes.func,
+  valueLabel: PropTypes.string,
+  mappingLabel: PropTypes.string,
+  title: PropTypes.string
+};
 
 export default StylePicker;

--- a/src/model/cytoscape-syncher.js
+++ b/src/model/cytoscape-syncher.js
@@ -410,7 +410,7 @@ export class CytoscapeSyncher {
     assertSelectorIsNodeOrEdge(selector);
     assertPropertyIsSupported(property, selector);
 
-    const _styles = cy.data('_styles') || {};
+    const _styles = this.cy.data('_styles') || {};
 
     _.set(_styles, [selector, property], value);
 
@@ -456,7 +456,7 @@ export class CytoscapeSyncher {
       throw new Error(`Can't set a bypass to a mapper`);
     }
 
-    const _bypasses = cy.data('_bypasses') || {};
+    const _bypasses = this.cy.data('_bypasses') || {};
     const ids = eles.map(ele => ele.id());
     const setBypassForId = id => _.set(_bypasses, [id, property], value);
 

--- a/src/model/style.js
+++ b/src/model/style.js
@@ -1,6 +1,15 @@
 import Color from 'color';
+import Cytoscape from 'cytoscape'; // eslint-disable-line
 
-/**  Style mapping types */
+/**
+ * @typedef {String} MAPPING
+ **/
+
+/**
+ * Style mapping type
+ * @readonly
+ * @enum {MAPPING}
+ */
 export const MAPPING = {
   /** A flat value (i.e. no mapping  */
   VALUE: 'VALUE',
@@ -18,7 +27,15 @@ const assertDataRangeOrder = (dataValue1, dataValue2) => {
   }
 };
 
-/** Supported style property types */
+/**
+ * @typedef {String} STYLE_TYPE
+ **/
+
+/**
+ * Supported style property types
+ * @readonly
+ * @enum {STYLE_TYPE}
+ */
 export const STYLE_TYPE = {
   /** A number */
   NUMBER: 'NUMBER',
@@ -33,6 +50,12 @@ const mapLinear = (x, x1, x2, f1, f2) => {
   return f1 + t * (f2 - f1);
 };
 
+/**
+ * Get the flat style value calculated for the 
+ * @param {Cytoscape.Collection} ele 
+ * @param {StyleStruct} styleStruct The style struct to calculate
+ * @returns {(String|Number)} A computed style value (string or number) that can be used directly as a Cytoscape style property value
+ */
 export const getFlatStyleForEle = (ele, styleStruct) => {
   const { mapping, type, value, stringValue } = styleStruct;
 
@@ -61,6 +84,82 @@ export const getFlatStyleForEle = (ele, styleStruct) => {
 };
 
 /**
+ * The style struct represents a style assignment as a plain JSON object
+ * @typedef {Object} StyleStruct
+ * @property {STYLE_TYPE} type The type of the style value (e.g. number)
+ * @property {MAPPING} mapping The type of mapping (flat value, linear, etc.)
+ * @property {String} stringValue The Cytoscape style value as a string
+ * @property value The value of the style assignment
+ */
+
+/**
+ * The style struct for a flat number property
+ * @typedef {Object} NumberStyleStruct
+ * @property {STYLE_TYPE} type The type of the style value (e.g. number)
+ * @property {MAPPING} mapping The type of mapping (flat value, linear, etc.)
+ * @property {String} stringValue The Cytoscape style value as a string
+ * @property {Number} value The value of the number
+ */
+
+/**
+ * @typedef {Object} LinearNumberStyleValue
+ * @property {String} data The data attribute that's mapped
+ * @property {Number} dataValue1 The minimum value of the input data range
+ * @property {Number} dataValue2 The maximum value of the inputn data range
+ * @property {Number} styleValue1 The minimum output style property number
+ * @property {Number} styleValue2 The minimum output style property number
+ */
+
+/**
+ * The style struct for a flat number property
+ * @typedef {Object} LinearNumberStyleStruct
+ * @property {STYLE_TYPE} type The type of the style value (e.g. number)
+ * @property {MAPPING} mapping The type of mapping (flat value, linear, etc.)
+ * @property {String} stringValue The Cytoscape style value as a string
+ * @property {LinearNumberStyleValue} value The value of the number mapping
+ */
+
+/**
+ * A color object used in the style struct
+ * @typedef {Object} RgbColor
+ * @property {Number} r The red value on [0, 255]
+ * @property {Number} g The green value on [0, 255]
+ * @property {Number} b The blue value on [0, 255]
+ */
+
+/**
+ * The style struct for a flat color
+ * @typedef {Object} ColorStyleStruct
+ * @property {STYLE_TYPE} type The type of the style value (e.g. number)
+ * @property {MAPPING} mapping The type of mapping (flat value, linear, etc.)
+ * @property {String} stringValue The Cytoscape style value as a string
+ * @property {RgbColor} value The value of the style assignment
+ */
+
+/**
+ * @typedef {Object} LinearColorStyleValue
+ * @property {String} data The data attribute that's mapped
+ * @property {Number} dataValue1 The minimum value of the input data range
+ * @property {Number} dataValue2 The maximum value of the inputn data range
+ * @property {RgbColor} styleValue1 The minimum output style property color
+ * @property {RgbColor} styleValue2 The minimum output style property color
+ */
+
+/**
+ * The style struct for a linear color mapping
+ * @typedef {Object} LinearColorStyleValue
+ */
+
+/**
+ * The style struct for a linear color property
+ * @typedef {Object} LinearColorStyleStruct
+ * @property {STYLE_TYPE} type The type of the style value (e.g. number)
+ * @property {MAPPING} mapping The type of mapping (flat value, linear, etc.)
+ * @property {String} stringValue The Cytoscape style value as a string
+ * @property {LinearColorStyleValue} value The value of the number mapping
+ */
+
+/**
  * The `styleFactory` creates style property values that can be used to set style.
  *  
  * `cySyncher.setStyle('node', 'width', styleFactory.number(20))`
@@ -69,7 +168,7 @@ export const styleFactory = {
   /**
    * Create a flat number
    * @param {Number} value The value of the number
-   * @returns {StyleValue} The style value object (JSON)
+   * @returns {NumberStyleStruct} The style value object (JSON)
    */
   number: value => {
     return {
@@ -87,7 +186,7 @@ export const styleFactory = {
    * @param {Number} dataValue2 The top value of the input range of data values to map
    * @param {Number} styleValue1 The bottom value of the output range of style values to map
    * @param {Number} styleValue2 The top value of the output range of style values to map
-   * @returns {StyleValue} The style value object (JSON)
+   * @returns {LinearNumberStyleStruct} The style value object (JSON)
    */
   linearNumber: (data, dataValue1, dataValue2, styleValue1, styleValue2) => {
     assertDataRangeOrder(dataValue1, dataValue2);
@@ -109,7 +208,7 @@ export const styleFactory = {
   /**
    * Create a flat color value
    * @param {Color} value The color value
-   * @returns {StyleValue} The style value object (JSON)
+   * @returns {ColorStyleStruct} The style value object (JSON)
    */
   color: value => {
     const { r, g, b } = Color(value).rgb().object();
@@ -129,7 +228,7 @@ export const styleFactory = {
    * @param {Number} dataValue2 The top value of the input range of data values to map
    * @param {Color} styleValue1 The bottom value of the output range of color values to map
    * @param {Color} styleValue2 The top value of the output range of color values to map
-   * @returns {StyleValue} The style value object (JSON)
+   * @returns {LinearColorStyleStruct} The style value object (JSON)
    */
   linearColor: (data, dataValue1, dataValue2, styleValue1, styleValue2) => {
     assertDataRangeOrder(dataValue1, dataValue2);
@@ -192,7 +291,7 @@ export const stylePropertyExists = (property, selector) => {
   } else if( selector === 'node' ){
     return nodeStylePropertyExists(property);
   } else {
-    return edgeStylePropertyExists(property)
+    return edgeStylePropertyExists(property);
   }
 };
 


### PR DESCRIPTION
- Clears out general linting errors
- Adds rect prop types
- Adds jsdoc typedefs for controller and style
- @mikekucera TODO document the component classes/functions and their constructors (other methods not necessary)

@mikekucera, would you update your style picker material ui branch with these changes?  That should make your branch get a green check for travis.