### PR TITLE
Create a warning for manual bypasses

### DIFF
--- a/src/client/cy.js
+++ b/src/client/cy.js
@@ -1,6 +1,19 @@
-import cytoscape from 'cytoscape';
+import Cytoscape from 'cytoscape';
 import edgehandles from 'cytoscape-edgehandles';
 
 export const registerCytoscapeExtensions = () => {
-  cytoscape.use(edgehandles);
+  Cytoscape.use(edgehandles);
+
+  const cy = new Cytoscape();
+  const ele = cy.add({});
+
+  const oldStyle = Object.getPrototypeOf(ele).style;
+
+  Object.getPrototypeOf(ele).style = function(){
+    if( process.NODE_ENV !== 'production' ){
+      console.warn(`Setting manual bypasses will not apply synchronised style for the graph.  Use the 'CytoscapeSyncher' methods.  You can safely ignore this warning for temporary ad-hoc bypasses set by extensions.`);
+    }
+
+    oldStyle.apply(this, arguments);
+  };
 };


### PR DESCRIPTION
- `ele.style()` bypasses are not synched with the server.  They are separate from the synchronised style.
- An `ele.style()` bypass should not normally be created by the app.
- An `ele.style()` bypass may be used by an extension (e.g. on temporary preview elements created for drawing edges via the edgehandles extension).
- When a Cytoscape bypass is created via `ele.style(prop, val)`, a warning is printed to the console.   This warning occurs only in debug mode.  The warning is collapsed by default, but it can be expanded to see the stack trace.  The stack trace can show you whether the bypass is valid (e.g. from an extension) or invalid (e.g. from the style UI).

An example warning that has been expanded:

<img width="1183" alt="Screen Shot 2020-10-19 at 10 19 37 AM" src="https://user-images.githubusercontent.com/989043/96464331-ae11e480-11f5-11eb-9aae-dc4899994fe0.png">

Clicking the stack trace shows the offending source code:

<img width="1183" alt="Screen Shot 2020-10-19 at 10 20 32 AM" src="https://user-images.githubusercontent.com/989043/96464414-ca158600-11f5-11eb-9a3c-bbaef84c091d.png">

