### PR TITLE
Fixes a couple of page layout issues

### DIFF
--- a/src/client/components/network-editor/header.js
+++ b/src/client/components/network-editor/header.js
@@ -81,7 +81,7 @@ export class Header extends Component {
     return (
       <>
         <div className="header">
-          <AppBar position="absolute">
+          <AppBar position="relative">
             <Toolbar variant="dense">
               <div className="icon logo" />
               <Typography variant="h6">

--- a/src/client/components/network-editor/index.js
+++ b/src/client/components/network-editor/index.js
@@ -162,13 +162,11 @@ export class NetworkEditor extends Component {
     return (
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <div>
+        <div className="network-editor">
           <Header controller={controller} />
-          <div className="network-editor">
-            <div id="cy" className="cy" />
-            <ToolPanel controller={controller} />
-            <StylePanel controller={controller} />
-          </div>
+          <div id="cy" className="cy" />
+          <ToolPanel controller={controller} />
+          <StylePanel controller={controller} />
         </div>
       </ThemeProvider>
     );

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -17,6 +17,12 @@ body {
   outline: none !important;
 }
 
+.network-editor {
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+}
+
 input[type='text'],
 input[type='date'],
 input[type='week'],

--- a/src/styles/components/network-editor/cy.css
+++ b/src/styles/components/network-editor/cy.css
@@ -1,5 +1,3 @@
 #cy {
-  position: absolute;
-  width: 100%;
-  height: 100%;
+  flex: 1 1 auto;
 }

--- a/src/styles/components/network-editor/header.css
+++ b/src/styles/components/network-editor/header.css
@@ -1,5 +1,5 @@
 .header {
-  flex-grow: 1;
+  flex: 0 1 auto;
 }
 
 .header .logo {
@@ -9,10 +9,6 @@
   margin-top: 0.25em;
   margin-bottom: 0.25em;
   margin-right: 1em;
-}
-
-.header .title {
-  flex-grow: 1;
 }
 
 .header .menu-button {


### PR DESCRIPTION
- the header could scroll up accidentally and seem to disappear;
- the height of the '#cy' box was too large, so networks would not fit to screen properly.

It worked fine on Android/Chrome but I haven't tested it on iOS.
Feel free to modify it as needed.