### PR TITLE
Make the network ID immutable

### DIFF
--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -47,10 +47,8 @@ export class NetworkEditorController {
    */
   setNetwork(elements, data, style) {
     this.cy.elements().remove();
-    this.cy.removeData();
-    
+    this.cy.data({ name: data.name }); // TODO: Set other NETWORK attributes, but ignore some of them (e.g. 'selected').
     this.cy.add(elements);
-    this.cy.data(data);
 
     if (style) {
       // TODO: This convertions are only necessary until we receive the correct Style object ====

--- a/src/model/cytoscape-syncher.js
+++ b/src/model/cytoscape-syncher.js
@@ -88,7 +88,9 @@ export class CytoscapeSyncher {
       data: _.clone(cy.data())
     };
 
-    await localDb.put(_.clone(doc));
+    const putRes = await localDb.put(_.clone(doc));
+
+    this.cy.scratch({ rev: putRes.rev });
 
     // do initial, one-way synch from local db to server db
     const info = await localDb.replicate.to(remoteDb);


### PR DESCRIPTION
- This makes the network ID immutable so you don't accidentally overwrite it or delete it (e.g. in our ad hoc import).
- Aside: Fix for initial `cy` PouchDB `rev`.  This resolves the current import issue where the styles do not persist after a refresh. 