### PR TITLE
Creating new networks

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,4 @@ NODE_ENV=development
 PORT=3000
 LOG_LEVEL=info
 COUCHDB_URL=http://localhost:5984
-BASE_URL=http://localhost
+BASE_URL=http://localhost:3000

--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ NODE_ENV=development
 PORT=3000
 LOG_LEVEL=info
 COUCHDB_URL=http://localhost:5984
+BASE_URL=http://localhost

--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ PORT=3000
 LOG_LEVEL=info
 COUCHDB_URL=http://localhost:5984
 BASE_URL=http://localhost:3000
+UPLOAD_LIMIT=1mb

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The following environment variables can be used to configure the server:
 - `COUCHDB_URL` : the URL of the CouchDB instance that the server should permanently store its data
 - `LOG_SYNC` : log CouchDB operations when set to `true`
 - `LOG_VIZMAPPER` : log VizMapper operations when set to `true`
+- `BASE_URL` : the base url of the server (e.g. `https://example.com`)
+- `UPLOAD_LIMIT` : max network upload size (e.g. `20kb`)
 
 
 ## Run targets

--- a/package-lock.json
+++ b/package-lock.json
@@ -3607,9 +3607,9 @@
       }
     },
     "cytoscape-dagre": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-2.3.1.tgz",
-      "integrity": "sha512-6IEs0dzXNuftxhL52oueFExYKQGJDYhhIhPfr0GIHLSTCSBoGwdEeEGWnNdFXh6epv0u+3A6INR+9un/vCiaOg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-2.3.2.tgz",
+      "integrity": "sha512-dL9+RvGkatSlIdOKXiFwHpnpTo8ydFMqIYzZFkImJXNbDci3feyYxR46wFoaG9GFiWimc6XD9Lm0x29b1wvWpw==",
       "requires": {
         "dagre": "^0.8.5"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cookie-parser": "^1.4.5",
     "cytoscape": "git+https://github.com/cytoscape/cytoscape.js.git#unstable",
     "cytoscape-cola": "^2.4.0",
-    "cytoscape-dagre": "^2.3.1",
+    "cytoscape-dagre": "^2.3.2",
     "cytoscape-edgehandles": "^3.6.0",
     "cytoscape-fcose": "^1.2.3",
     "cytoscape-popper": "^1.0.6",

--- a/src/client/components/network-editor/header.js
+++ b/src/client/components/network-editor/header.js
@@ -20,6 +20,7 @@ import Divider from '@material-ui/core/Divider';
 import Tooltip from '@material-ui/core/Tooltip';
 import LayoutPanel from '../layout/layout-panel';
 import Cy3NetworkImportDialog from '../network-import/cy3-network-import-dialog';
+import uuid from 'uuid';
 
 
 /**
@@ -93,6 +94,11 @@ export class Header extends Component {
     this.busProxy.removeAllListeners();
   }
 
+  // temp: should be somewhere else, e.g. in network management page
+  createNewNetwork(){
+    window.open(`/document/cy${uuid()}`);
+  }
+
   render() {
     const { networkName, anchorEl, menuName, dialogName } = this.state;
     const cy = this.controller.cy;
@@ -140,6 +146,7 @@ export class Header extends Component {
                   <MenuList>
                     <MenuItem disabled={cy.nodes().length === 0} onClick={() => this.showDialog('layout', 'main')}>Layout</MenuItem>
                     <MenuItem disabled={false} onClick={() => this.showDialog('network-import')}>Import Network From Cytoscape</MenuItem>
+                    <MenuItem onClick={() => this.createNewNetwork()}>Create new network</MenuItem>
                   </MenuList>
                 )}
                 {dialogName === 'layout' && (

--- a/src/client/components/network-editor/index.js
+++ b/src/client/components/network-editor/index.js
@@ -20,6 +20,8 @@ export class NetworkEditor extends Component {
   constructor(props){
     super(props);
 
+    const id = _.get(props, ['match', 'params', 'id']);
+
     this.bus = new EventEmitter();
 
     this.cy = new Cytoscape({
@@ -30,7 +32,7 @@ export class NetworkEditor extends Component {
     this.cyEmitter = new EventEmitterProxy(this.cy);
 
     // use placeholder id and secret for now...
-    this.cy.data({ id: 'networkid', name: 'New Network' });
+    this.cy.data({ id, name: 'New Network' });
 
     this.cySyncher = new CytoscapeSyncher(this.cy, 'secret');
 
@@ -219,7 +221,8 @@ class NetworkBackground extends Component {
 }
 
 NetworkBackground.propTypes = {
-  controller: PropTypes.instanceOf(NetworkEditorController)
+  controller: PropTypes.instanceOf(NetworkEditorController),
+  match: PropTypes.object
 };
 
 export default NetworkEditor; 

--- a/src/client/components/style/shapes.js
+++ b/src/client/components/style/shapes.js
@@ -61,7 +61,7 @@ export function ShapeIcon({ type, shape, onClick }) {
 }
 
 ShapeIcon.propTypes = {
-  type: PropTypes.oneOf('node', 'line', 'arrow'),
+  type: PropTypes.oneOf(['node', 'line', 'arrow']),
   shape: PropTypes.oneOf([
     'ellipse', 'rectangle', 'round-rectangle', 'rhomboid', 'triangle', 'diamond', 'hexagon', 'octagon', 'vee',
     'solid', 'dotted', 'dashed',

--- a/src/client/components/tippy-popover.js
+++ b/src/client/components/tippy-popover.js
@@ -22,13 +22,15 @@ export const TippyPopover = props => (
     }}
     content={props.content} 
     { ...props }>
-      { props.children }
+      <div>
+        { props.children }
+      </div>
   </Tippy>
 );
 
 TippyPopover.propTypes = {
-  content: PropTypes.Component,
-  children: PropTypes.Component
+  content: PropTypes.element,
+  children: PropTypes.any
 };
 
 export default TippyPopover;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -4,7 +4,7 @@ import debug from './debug';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router } from './router';
-import { registerCytoscapeExtensions } from './cy';
+import { registerCytoscapeExtensions } from '../model/cy-extensions';
 
 PouchDB.plugin(PouchDBMemoryAdapter);
 

--- a/src/client/router.js
+++ b/src/client/router.js
@@ -1,21 +1,16 @@
 import React from 'react';
-import { BrowserRouter, Route, Switch } from "react-router-dom";
+import { BrowserRouter, Route, Switch, Redirect } from "react-router-dom";
 import NetworkEditor from './components/network-editor';
 import PageNotFound from './components/page-not-found';
 
 export const Router = () => (
   <BrowserRouter>
     <Switch>
-      <Route
-        path='/'
-        component={NetworkEditor}
-        exact 
-      />
-      <Route 
-        status={404} 
-        component={PageNotFound} 
-        exact 
-      />
+      <Route path='/' exact>
+        <Redirect to='/document/demo' />
+      </Route>
+      <Route path='/document/:id' component={NetworkEditor} />
+      <Route status={404} component={PageNotFound} exact />
     </Switch>
   </BrowserRouter>
 );

--- a/src/model/cy-extensions.js
+++ b/src/model/cy-extensions.js
@@ -1,6 +1,6 @@
 import Cytoscape from 'cytoscape';
 import edgehandles from 'cytoscape-edgehandles';
-import VizMapper from '../model/vizmapper';
+import VizMapper from './vizmapper';
 import dagre from 'cytoscape-dagre';
 import fcose from 'cytoscape-fcose';
 import cola from 'cytoscape-cola';

--- a/src/model/cytoscape-syncher.js
+++ b/src/model/cytoscape-syncher.js
@@ -37,6 +37,7 @@ export class CytoscapeSyncher {
 
     this.enabled = false;
     this.loadedOrCreated = false;
+    this.listenersAdded = false;
 
     this.cy = cy;
     this.secret = secret;
@@ -175,8 +176,11 @@ export class CytoscapeSyncher {
    * @private
    */
   addListeners(){
+    if(this.listenersAdded){ return; }
+
     this.dirtyEles = this.cy.collection();
     this.dirtyCy = false;
+    this.listenersAdded = true;
 
     const ignoreTargetEle = target => (
       target.hasClass('eh-handle')
@@ -361,12 +365,18 @@ export class CytoscapeSyncher {
    * @private
    */
   removeListeners(){
+    if(!this.listenersAdded){ return; }
+
     this.cyEmitter.removeAllListeners();
 
-    this.synchHandler.cancel();
-    this.synchHandler.removeAllListeners();
+    if(this.synchHandler){
+      this.synchHandler.cancel();
+      this.synchHandler.removeAllListeners();
+    }
 
     clearTimeout(this.synchTimeout);
+
+    this.listenersAdded = false;
   }
 
   /**

--- a/src/model/cytoscape-syncher.js
+++ b/src/model/cytoscape-syncher.js
@@ -89,9 +89,21 @@ export class CytoscapeSyncher {
       data: _.clone(cy.data())
     };
 
-    const putRes = await localDb.put(_.clone(doc));
+    const putRes = await localDb.put(doc);
 
     this.cy.scratch({ rev: putRes.rev });
+
+    this.cy.elements().forEach(async ele => {
+      const doc = {
+        _id: ele.id(),
+        data: _.clone(ele.data()),
+        position: _.clone(ele.position())
+      };
+
+      const putRes = await localDb.put(doc);
+
+      ele.scratch({ rev: putRes.rev });
+    });
 
     // do initial, one-way synch from local db to server db
     const info = await localDb.replicate.to(remoteDb);

--- a/src/model/cytoscape-syncher.js
+++ b/src/model/cytoscape-syncher.js
@@ -375,6 +375,9 @@ export class CytoscapeSyncher {
    */
   destroy(){
     this.removeListeners();
+
+    this.localDb.close();
+    this.remoteDb.close();
   }
 }
 

--- a/src/model/import-export/cx.js
+++ b/src/model/import-export/cx.js
@@ -1,0 +1,23 @@
+/**
+ * Import CX into a Cytoscape instance
+ * @param {Cytoscape.Core} cy 
+ * @param {*} cx 
+ */
+export const importCX = (cy, cx) => {
+  // TODO set cy data from cx
+  cy.data({ cx });
+
+  // TODO add eles to cy from cx
+  const eles = [];
+  cy.add(eles);
+};
+
+/**
+ * Export a Cytoscape instance to CX format
+ * @param {Cytoscape.Core} cy 
+ */
+export const exportCX = (cy) => {
+  const cx = { data: cy.data() }; // TODO convert cy data to CX
+
+  return cx;
+};

--- a/src/model/import-export/json.js
+++ b/src/model/import-export/json.js
@@ -1,0 +1,30 @@
+/**
+ * Import JSON into a Cytoscape instance
+ * @param {Cytoscape.Core} cy 
+ * @param {Object} json 
+ */
+export const importJSON = (cy, json) => {
+  const { data, elements } = json;
+
+  cy.data(data);
+  cy.add(elements);
+};
+
+/**
+ * Export a Cytoscape instance to JSON format
+ * @param {Cytoscape.Core} cy 
+ */
+export const exportJSON = (cy) => {
+  return {
+    data: cy.data(),
+    elements: cy.elements().map(ele => {
+      const eleJson = {};
+
+      eleJson.data = ele.data();
+      
+      if(ele.isNode()){ eleJson.position = ele.position(); }
+
+      return eleJson;
+    })
+  };
+};

--- a/src/model/vizmapper.js
+++ b/src/model/vizmapper.js
@@ -1,8 +1,11 @@
 import { CytoscapeSyncher } from './cytoscape-syncher'; // eslint-disable-line
-import { StyleStruct } from './style'; // eslint-disable-line
 import { MAPPING, STYLE_TYPE, NODE_STYLE_PROPERTIES, EDGE_STYLE_PROPERTIES, DEFAULT_NODE_STYLE, DEFAULT_EDGE_STYLE, stylePropertyExists, getFlatStyleForEle, PROPERTY_TYPE } from './style';
 import _ from 'lodash';
 import { EventEmitterProxy } from './event-emitter-proxy';
+
+/**
+ * @typedef {import('./style').StyleStruct} StyleStruct
+ */
 
 const NODE_SELECTOR = 'node';
 const EDGE_SELECTOR = 'edge';

--- a/src/server/env.js
+++ b/src/server/env.js
@@ -11,3 +11,4 @@ export const NODE_ENV = process.env.NODE_ENV;
 export const PORT = parseInt(process.env.PORT, 10);
 export const LOG_LEVEL = process.env.LOG_LEVEL;
 export const COUCHDB_URL = process.env.COUCHDB_URL;
+export const BASE_URL = process.env.BASE_URL;

--- a/src/server/env.js
+++ b/src/server/env.js
@@ -12,3 +12,4 @@ export const PORT = parseInt(process.env.PORT, 10);
 export const LOG_LEVEL = process.env.LOG_LEVEL;
 export const COUCHDB_URL = process.env.COUCHDB_URL;
 export const BASE_URL = process.env.BASE_URL;
+export const UPLOAD_LIMIT = process.env.UPLOAD_LIMIT;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -11,7 +11,7 @@ import fs from 'fs';
 import proxy from 'express-http-proxy';
 import stream from 'stream';
 
-import { NODE_ENV, PORT, COUCHDB_URL } from './env';
+import { NODE_ENV, PORT, COUCHDB_URL, UPLOAD_LIMIT } from './env';
 import indexRouter from './routes/index';
 import apiRouter from './routes/api';
 import { registerCytoscapeExtensions } from '../model/cy-extensions';
@@ -56,7 +56,7 @@ app.use(morgan('dev', {
 // proxy requests under /db to the CouchDB server
 app.use('/db', proxy(COUCHDB_URL));
 
-app.use(bodyParser.json());
+app.use(bodyParser.json({ limit: UPLOAD_LIMIT }));
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, '../..', 'public')));

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -14,11 +14,14 @@ import stream from 'stream';
 import { NODE_ENV, PORT, COUCHDB_URL } from './env';
 import indexRouter from './routes/index';
 import apiRouter from './routes/api';
+import { registerCytoscapeExtensions } from '../model/cy-extensions';
 
 import PouchDB from 'pouchdb';
 import PouchDBMemoryAdapter from 'pouchdb-adapter-memory';
 
+// extensions/plugins
 PouchDB.plugin(PouchDBMemoryAdapter);
+registerCytoscapeExtensions();
 
 const debugLog = debug('cytoscape-home:server');
 const app = express();

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -112,4 +112,4 @@ function onListening() {
   debugLog('Listening on ' + bind);
 }
 
-module.exports = app;
+export default app;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -8,9 +8,17 @@ import debug from 'debug';
 import http from 'http';
 import logger from './logger';
 import fs from 'fs';
-import { NODE_ENV, PORT, COUCHDB_URL } from './env';
 import proxy from 'express-http-proxy';
 import stream from 'stream';
+
+import { NODE_ENV, PORT, COUCHDB_URL } from './env';
+import indexRouter from './routes/index';
+import apiRouter from './routes/api';
+
+import PouchDB from 'pouchdb';
+import PouchDBMemoryAdapter from 'pouchdb-adapter-memory';
+
+PouchDB.plugin(PouchDBMemoryAdapter);
 
 const debugLog = debug('cytoscape-home:server');
 const app = express();
@@ -50,7 +58,8 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, '../..', 'public')));
 
-app.use('/', require('./routes/index'));
+app.use('/api', apiRouter);
+app.use('/', indexRouter);
 
 // catch 404 and forward to error handler
 app.use(function(req, res) {

--- a/src/server/routes/api/document.js
+++ b/src/server/routes/api/document.js
@@ -1,0 +1,117 @@
+import Express from 'express';
+import uuid from 'uuid';
+import Cytoscape from 'cytoscape';
+import CytoscapeSyncher from '../../../model/cytoscape-syncher';
+import { BASE_URL } from '../../env';
+import { importCX, exportCX } from '../../../model/import-export/cx';
+import { importJSON, exportJSON } from '../../../model/import-export/json';
+
+const http = Express.Router();
+
+const makeNetworkId = () => 'cy' + uuid();
+
+/**
+ * Post (create) a new network
+ * @param {Function} importBody A function that takes (cy, body) and converts the body to cy
+ * @param {Express.Request} req The HTTP request
+ * @param {Express.Response} res The HTTP response
+ * @param {Express.NextFunction} next The Express next(err) function
+ */
+const postNetwork = async (importBody, req, res, next) => {
+  try {
+    const body = req.body;
+    const id = makeNetworkId();
+    const cy = new Cytoscape();
+
+    cy.data({ id });
+
+    importBody(cy, body);
+
+    const cySyncher = new CytoscapeSyncher(cy, 'secret');
+
+    await cySyncher.create();
+
+    cySyncher.destroy();
+    cy.destroy();
+
+    res.send({
+      id,
+      url: `${BASE_URL}/document/${id}`
+    });
+  } catch(err) {
+    next(err);
+  }
+};
+
+/**
+ * Get a network
+ * @param {Function} exportCy A function that takes (cy) and returns the desired format
+ * @param {Express.Request} req The HTTP request
+ * @param {Express.Response} res The HTTP response
+ * @param {Express.NextFunction} next The Express next(err) function
+ */
+const getNetwork = async (exportCy, req, res, next) => {
+  try {
+    const { id } = req.params;
+    const cy = new Cytoscape();
+
+    cy.data({ id });
+
+    const cySyncher = new CytoscapeSyncher(cy, 'secret');
+
+    await cySyncher.load();
+
+    const payload = exportCy(cy);
+
+    cySyncher.destroy();
+    cy.destroy();
+
+    res.send(payload);
+  } catch(err) {
+    next(err);
+  }
+};
+
+/**
+ * Create a new network document
+ */
+http.post('/', async function(req, res, next) {
+  await postNetwork(importJSON, req, res, next);
+});
+
+/**
+ * Get a network document
+ */
+http.get('/:id', async function(req, res, next){
+  await getNetwork(exportJSON, req, res, next);
+});
+
+/**
+ * Create a new network document from JSON format
+ */
+http.post('/json', async function(req, res, next) {
+  await postNetwork(importJSON, req, res, next);
+});
+
+/**
+ * Get a network document in JSON format
+ */
+http.get('/json/:id', async function(req, res, next){
+  await getNetwork(exportJSON, req, res, next);
+});
+
+/**
+ * Create a new network document from CX format
+ */
+http.post('/json', async function(req, res, next) {
+  await postNetwork(importCX, req, res, next);
+});
+
+/**
+ * Get a network document in CX format
+ */
+http.get('/json/:id', async function(req, res, next){
+  await getNetwork(exportCX, req, res, next);
+});
+
+export default http;

--- a/src/server/routes/api/document.js
+++ b/src/server/routes/api/document.js
@@ -23,9 +23,8 @@ const postNetwork = async (importBody, req, res, next) => {
     const id = makeNetworkId();
     const cy = new Cytoscape();
 
-    cy.data({ id });
-
     importBody(cy, body);
+    cy.data({ id });
 
     const cySyncher = new CytoscapeSyncher(cy, 'secret');
 

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -1,0 +1,8 @@
+import Express from 'express';
+import documentRouter from './document';
+
+const http = Express.Router();
+
+http.use('/document', documentRouter);
+
+export default http;

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -15,4 +15,5 @@ if( NODE_ENV !== 'production' ){
   });
 }
 
-module.exports = router;
+export default router;
+


### PR DESCRIPTION
Changes:
- Add POST `/api/document` route to create a new network.
- Add a GET `/api/document/:id` route to get a network's data.
- There are corresponding routes for JSON and CX, e.g. POST `/api/document/cx`.
- Add import/export modules:  There is a JSON module that currently works for everything apart from style.  There is a CX importer and a CX exporter stubbed out for @jingjingbic  and @dotasek to complete in a future PR.
- There is a new, temporary menu item in the editor to create a new network.
- N.b. databases in CouchDB must start with a letter, so all network IDs are prefixed with `cy`, e.g. `cy1558e499-a192-43fa-8f10-56aa4e8ec2ee`.

Misc.
- Updates dagre.
- Fixes some prop types warnings in the icons and tippy components.

New menu item:

<img width="317" alt="Screen Shot 2020-12-11 at 12 50 25" src="https://user-images.githubusercontent.com/989043/101937764-47cf8f80-3bb0-11eb-9140-a6e6064c71a6.png">
