### PR TITLE
Basic support for style bypasses in the style picker.

### DIFF
--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -254,9 +254,9 @@ export class NetworkEditorController {
    * Returns true if there are 1 or more elements selected.
    * @param {String} selector The cyjs selector, 'node' or 'edge'.
    */
-  isBypassing(selector) {
+  bypassCount(selector) {
     const selected = this.cy.$(selector+':selected');
-    return !selected.empty();
+    return selected.size();
   }
 
   /**
@@ -297,15 +297,14 @@ export class NetworkEditorController {
    * Set a color propetry of all elements to single color.
    * @param {String} selector 'node' or 'edge'
    * @param {String} property a style property that expects a color value, such as 'background-color'
-   * @param {(Color|String)} color The color to set
+   * @param {(Color|String)} color The color to set, or null to clear the style.
    */
   setColor(selector, property, color) {
     const selected = this.cy.$(selector+':selected');
     if(!selected.empty())
-      this.vizmapper.bypass(selected, property, styleFactory.color(color));
+      this.vizmapper.bypass(selected, property, color == null ? null : styleFactory.color(color));
     else
       this.vizmapper.set(selector, property, styleFactory.color(color));
-    console.log("okay");
     this.bus.emit('setColor', selector, property, color);
   }
 
@@ -348,7 +347,7 @@ export class NetworkEditorController {
   setNumber(selector, property, value) {
     const selected = this.cy.$(selector+':selected');
     if(!selected.empty())
-      this.vizmapper.bypass(selected, property, styleFactory.number(value));
+      this.vizmapper.bypass(selected, property, value == null ? null : styleFactory.number(value));
     else
       this.vizmapper.set(selector, property, styleFactory.number(value));
     this.bus.emit('setNumber', selector, property, value);
@@ -395,7 +394,7 @@ export class NetworkEditorController {
   setString(selector, property, text) {
     const selected = this.cy.$(selector+':selected');
     if(!selected.empty())
-      this.vizmapper.bypass(selected, property, styleFactory.string(text));
+      this.vizmapper.bypass(selected, property, text == null ? null : styleFactory.string(text));
     else
       this.vizmapper.set(selector, property, styleFactory.string(text));
     this.bus.emit('setString', selector, property, text);

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -251,7 +251,15 @@ export class NetworkEditorController {
   }
 
   /**
-   * 
+   * Returns true if there are 1 or more elements selected.
+   * @param {String} selector The cyjs selector, 'node' or 'edge'.
+   */
+  isBypassing(selector) {
+    const selected = this.cy.$(selector+':selected');
+    return !selected.empty();
+  }
+
+  /**
    * @param {String} selector The cyjs selector, 'node' or 'edge'.
    * @param {String} attribute The data attribute name.
    */
@@ -292,7 +300,12 @@ export class NetworkEditorController {
    * @param {(Color|String)} color The color to set
    */
   setColor(selector, property, color) {
-    this.vizmapper.set(selector, property, styleFactory.color(color));
+    const selected = this.cy.$(selector+':selected');
+    if(!selected.empty())
+      this.vizmapper.bypass(selected, property, styleFactory.color(color));
+    else
+      this.vizmapper.set(selector, property, styleFactory.color(color));
+    console.log("okay");
     this.bus.emit('setColor', selector, property, color);
   }
 
@@ -333,7 +346,11 @@ export class NetworkEditorController {
    * @param {Number} value The value to set
    */
   setNumber(selector, property, value) {
-    this.vizmapper.set(selector, property, styleFactory.number(value));
+    const selected = this.cy.$(selector+':selected');
+    if(!selected.empty())
+      this.vizmapper.bypass(selected, property, styleFactory.number(value));
+    else
+      this.vizmapper.set(selector, property, styleFactory.number(value));
     this.bus.emit('setNumber', selector, property, value);
   }
 
@@ -376,7 +393,11 @@ export class NetworkEditorController {
    * @param {Number} text The value to set
    */
   setString(selector, property, text) {
-    this.vizmapper.set(selector, property, styleFactory.string(text));
+    const selected = this.cy.$(selector+':selected');
+    if(!selected.empty())
+      this.vizmapper.bypass(selected, property, styleFactory.string(text));
+    else
+      this.vizmapper.set(selector, property, styleFactory.string(text));
     this.bus.emit('setString', selector, property, text);
   }
 

--- a/src/client/components/style/style-picker.js
+++ b/src/client/components/style/style-picker.js
@@ -13,7 +13,8 @@ import { MAPPING } from '../../../model/style';
 
 const TAB = {
   VALUE: 'VALUE',
-  MAPPING: 'MAPPING'
+  MAPPING: 'MAPPING',
+  BYPASSING: 'BYPASSING'
 };
 
 export class StylePicker extends React.Component { 
@@ -39,12 +40,27 @@ export class StylePicker extends React.Component {
     };
   }
 
+
   onShow() {
+    this.setState({ initialized: true });
+
+    if(this.controller.isBypassing(this.props.selector)) {
+      this.setState({ 
+        tab: TAB.BYPASSING,
+        style: {
+          mapping: MAPPING.VALUE,
+          discreteValue: {},
+        }
+      });
+      return;
+    }
+
     const style = this.props.getStyle();
+
     this.setState({ 
-      initialized: true,
       tab: style.mapping == MAPPING.VALUE ? TAB.VALUE : TAB.MAPPING
     });
+
     switch(style.mapping) {
       case MAPPING.VALUE:
         this.setState({ style: {
@@ -130,6 +146,7 @@ export class StylePicker extends React.Component {
     return this.renderTabs();
   }
 
+
   renderTabs() {
     return (
       <div className="style-picker">
@@ -137,15 +154,20 @@ export class StylePicker extends React.Component {
           <div className="style-picker-heading">
             {this.props.title || "Visual Property"}
           </div>
-          <BottomNavigation
-            value={this.state.tab}
-            onChange={(event, tab) => this.handleTabChange(tab)}
-            showLabels >
-            <BottomNavigationAction label="DEFAULT" value={TAB.VALUE} />
-            <BottomNavigationAction label="MAPPING" value={TAB.MAPPING} />
-          </BottomNavigation>
+          { (this.state.tab === TAB.BYPASSING)
+            ? <div>
+                Setting style bypass
+              </div>
+            : <BottomNavigation
+                value={this.state.tab}
+                onChange={(event, tab) => this.handleTabChange(tab)}
+                showLabels >
+                <BottomNavigationAction label="DEFAULT" value={TAB.VALUE} />
+                <BottomNavigationAction label="MAPPING" value={TAB.MAPPING} />
+              </BottomNavigation>
+          }
         </Paper>
-        { this.state.tab === TAB.VALUE
+        { this.state.tab === TAB.VALUE || this.state.tab === TAB.BYPASSING
           ? this.renderSubComponentValue()
           : this.renderMapping()
         }

--- a/src/model/vizmapper.js
+++ b/src/model/vizmapper.js
@@ -176,7 +176,7 @@ export class VizMapper {
       assertPropertyIsSupported(property);
       assertValueIsSupported(value, property);
 
-      if( value.type !== MAPPING.VALUE ){
+      if( value.mapping !== MAPPING.VALUE ){
         throw new Error(`Can't set a bypass to a mapper`);
       }
 

--- a/src/model/vizmapper.js
+++ b/src/model/vizmapper.js
@@ -32,6 +32,12 @@ const assertPropertyIsSupported = (property, selector) => {
   }
 };
 
+const assertBypassValueIsSupported = (value, property) => {
+  if(value !== null) {
+    assertValueIsSupported(value, property);
+  }
+};
+
 const assertValueIsSupported = (value, property) => {
   if(value.type == null){
     throw new Error(`A style value must be generated from the 'styleFactory'.  This value object is invalid, as it's missing the 'type' field.`);
@@ -171,20 +177,22 @@ export class VizMapper {
    * @returns {StyleStruct} The current style (when `value` is unspecified)
    */
   bypass(eles, property, value){
-    if(value){
+    if(value || value === null) {
       assertElesNonempty(eles);
       assertPropertyIsSupported(property);
-      assertValueIsSupported(value, property);
+      assertBypassValueIsSupported(value, property);
 
-      if( value.mapping !== MAPPING.VALUE ){
+      if(value !== null && value.mapping !== MAPPING.VALUE) {
         throw new Error(`Can't set a bypass to a mapper`);
       }
 
       const _bypasses = this.cy.data('_bypasses') || {};
       const ids = eles.map(ele => ele.id());
-      const setBypassForId = id => _.set(_bypasses, [id, property], value);
 
-      ids.forEach(setBypassForId);
+      if(value === null)
+        ids.forEach(id => _.unset(_bypasses, [id, property]));
+      else
+        ids.forEach(id => _.set(_bypasses, [id, property], value));
 
       // store synched data
       this.cy.data({ _bypasses });


### PR DESCRIPTION
Allows style bypasses to be set when one or more nodes/edges are selected. Refs #52.

This does not implement a global "mode" for bypasses. It just switches the style picker to set or clear bypasses on selected elements.

I don't think this is final, any feedback on UI improvements is appreciated. Also, should we use the term "bypass" in the UI, or something else?

