### PR TITLE
Add secrets to allow for anonymous auth.

### DIFF
--- a/.env
+++ b/.env
@@ -2,5 +2,7 @@ NODE_ENV=development
 PORT=3000
 LOG_LEVEL=info
 COUCHDB_URL=http://localhost:5984
+COUCHDB_USER=admin
+COUCHDB_PASSWORD=admin
 BASE_URL=http://localhost:3000
 UPLOAD_LIMIT=1mb

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ The following environment variables can be used to configure the server:
 - `PORT` : the port on which the server runs (default 3000)
 - `LOG_LEVEL` : the log level for `out.log`
 - `COUCHDB_URL` : the URL of the CouchDB instance that the server should permanently store its data
+- `USE_COUCH_AUTH` : set to `true` if you want to use CouchDB auth via `COUCHDB_USER` & `COUCHDB_PASSWORD`
+- `COUCHDB_USER` : admin user name
+- `COUCHDB_PASSWORD` : admin user password
 - `LOG_SYNC` : log CouchDB operations when set to `true`
 - `LOG_VIZMAPPER` : log VizMapper operations when set to `true`
 - `BASE_URL` : the base url of the server (e.g. `https://example.com`)

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -70,6 +70,13 @@ export class NetworkEditorController {
   }
 
   /**
+   * Gets whether the network is editable
+   */
+  editable() {
+    return this.cySyncher.editable();
+  }
+
+  /**
    * Replaces the current network with the passed one.
    * @param {Object} [elements] Cytoscape elements object
    * @param {Object} [data] Cytoscape data object

--- a/src/client/components/network-editor/header.js
+++ b/src/client/components/network-editor/header.js
@@ -96,7 +96,27 @@ export class Header extends Component {
 
   // temp: should be somewhere else, e.g. in network management page
   createNewNetwork(){
-    window.open(`/document/cy${uuid()}`);
+    let create = async () => {
+      let res = await fetch('/api/document', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          data: {},
+          elements: [
+          ]
+        })
+      });
+
+      let body = await res.json();
+
+      console.log('Created network', body);
+
+      window.open(`${body.privateUrl}`);
+    };
+
+    create();
   }
 
   render() {

--- a/src/client/router.js
+++ b/src/client/router.js
@@ -9,6 +9,7 @@ export const Router = () => (
       <Route path='/' exact>
         <Redirect to='/document/demo' />
       </Route>
+      <Route path='/document/:id/:secret' component={NetworkEditor} />
       <Route path='/document/:id' component={NetworkEditor} />
       <Route status={404} component={PageNotFound} exact />
     </Switch>

--- a/src/model/cytoscape-syncher.js
+++ b/src/model/cytoscape-syncher.js
@@ -6,9 +6,9 @@ import { DocumentNotFoundError } from './errors';
 import _ from 'lodash';
 import Cytoscape from 'cytoscape'; // eslint-disable-line
 
-const PORT = process.env.PORT;
 const SYNC_INTERVAL = 400;
 
+const COUCHDB_URL = process.env.COUCHDB_URL;
 const COUCHDB_USER = process.env.COUCHDB_USER;
 const COUCHDB_PASSWORD = process.env.COUCHDB_PASSWORD;
 const USE_COUCH_AUTH = ('' + process.env.USE_COUCH_AUTH).toLowerCase() === 'true';
@@ -57,11 +57,11 @@ export class CytoscapeSyncher {
     this.emitter = new EventEmitter();
     this.cyEmitter = new EventEmitterProxy(this.cy);
 
-    const pouchOrigin = isClient() ? location.origin : `http://localhost:${PORT}`;
+    const pouchOrigin = isClient() ? location.origin : COUCHDB_URL;
     
     const remotePouchOptions = {
       fetch: (url, opts) => {
-        opts.headers.set('X-Secret', secret);
+        opts.headers.set('X-Secret', this.secret);
   
         return PouchDB.fetch(url, opts);
       }
@@ -74,14 +74,29 @@ export class CytoscapeSyncher {
       auth.password = COUCHDB_PASSWORD;
     }
 
-    this.localDb = new PouchDB(this.dbName, { adapter: 'memory' }); // store in memory to avoid multitab db event noise
-    this.remoteDb = new PouchDB(`${pouchOrigin}/db/${this.dbName}`, remotePouchOptions);
+    if (this.editable() || isServer()) {
+      this.localDb = new PouchDB(this.dbName, { adapter: 'memory' }); // store in memory to avoid multitab db event noise
+      
+      let remoteUrl;
+
+      if (isServer()) {
+        remoteUrl = `${pouchOrigin}/${this.dbName}`; // server gets unrestricted access
+      } else {
+        remoteUrl = `${pouchOrigin}/db/${this.dbName}`; // /db applied security
+      }
+      
+      this.remoteDb = new PouchDB(remoteUrl, remotePouchOptions);
+    }
 
     cy.scratch('_cySyncher', this);
   }
 
+  editable() {
+    return this.secret != null;
+  }
+
   enable(){
-    if( this.enabled ){ return; }
+    if(this.enabled || !this.editable()) { return; }
 
     this.enabled = true;
 
@@ -150,6 +165,16 @@ export class CytoscapeSyncher {
 
     const { cy, localDb, remoteDb, dbName, docId } = this;
 
+    if (!this.editable() && isClient()) { // load one-time read-only view
+      const res = await fetch(`/api/document/${this.networkId}`);
+      const json = await res.json();
+
+      if (json.data) { cy.data(json.data); }
+      if (json.elements) { cy.add(json.elements); }
+
+      return;
+    }
+
     // do initial, one-way synch from server db to local db
     const info = await localDb.replicate.from(remoteDb);
 
@@ -211,7 +236,7 @@ export class CytoscapeSyncher {
    * @private
    */
   addListeners(){
-    if(this.listenersAdded){ return; }
+    if (this.listenersAdded || !this.editable()) { return; }
 
     this.dirtyEles = this.cy.collection();
     this.dirtyCy = false;

--- a/src/model/cytoscape-syncher.js
+++ b/src/model/cytoscape-syncher.js
@@ -423,7 +423,6 @@ export class CytoscapeSyncher {
 
     this.localDb.close();
     this.remoteDb.close();
-    this.secretsDb.close();
   }
 }
 

--- a/src/model/import-export/json.js
+++ b/src/model/import-export/json.js
@@ -6,8 +6,14 @@
 export const importJSON = (cy, json) => {
   const { data, elements } = json;
 
-  cy.data(data);
-  cy.add(elements);
+
+  if (data) {
+    cy.data(data);
+  }
+  
+  if (elements && Array.isArray(elements) && elements.length > 0) {
+    cy.add(elements);
+  }
 };
 
 /**

--- a/src/server/env.js
+++ b/src/server/env.js
@@ -11,5 +11,8 @@ export const NODE_ENV = process.env.NODE_ENV;
 export const PORT = parseInt(process.env.PORT, 10);
 export const LOG_LEVEL = process.env.LOG_LEVEL;
 export const COUCHDB_URL = process.env.COUCHDB_URL;
+export const COUCHDB_USER = process.env.COUCHDB_USER;
+export const COUCHDB_PASSWORD = process.env.COUCHDB_PASSWORD;
+export const USE_COUCH_AUTH = ('' + process.env.USE_COUCH_AUTH).toLowerCase() === 'true';
 export const BASE_URL = process.env.BASE_URL;
 export const UPLOAD_LIMIT = process.env.UPLOAD_LIMIT;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -15,6 +15,7 @@ import { NODE_ENV, PORT, COUCHDB_URL, UPLOAD_LIMIT } from './env';
 import indexRouter from './routes/index';
 import apiRouter from './routes/api';
 import { registerCytoscapeExtensions } from '../model/cy-extensions';
+import { secrets } from './secrets';
 
 import PouchDB from 'pouchdb';
 import PouchDBMemoryAdapter from 'pouchdb-adapter-memory';
@@ -53,13 +54,14 @@ app.use(morgan('dev', {
   })
 }));
 
-// proxy requests under /db to the CouchDB server
-app.use('/db', proxy(COUCHDB_URL));
-
 app.use(bodyParser.json({ limit: UPLOAD_LIMIT }));
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, '../..', 'public')));
+
+// proxy requests under /db to the CouchDB server
+app.use('/db', secrets); // apply security before proxy
+app.use('/db', proxy(COUCHDB_URL));
 
 app.use('/api', apiRouter);
 app.use('/', indexRouter);

--- a/src/server/routes/api/document.js
+++ b/src/server/routes/api/document.js
@@ -22,21 +22,21 @@ const postNetwork = async (importBody, req, res, next) => {
     const body = req.body;
     const id = makeNetworkId();
     const cy = new Cytoscape();
+    const secret = uuid();
+    const publicUrl = `${BASE_URL}/document/${id}`;
+    const privateUrl = `${publicUrl}/secret`;
 
     importBody(cy, body);
     cy.data({ id });
 
-    const cySyncher = new CytoscapeSyncher(cy, 'secret');
+    const cySyncher = new CytoscapeSyncher(cy, secret);
 
     await cySyncher.create();
 
     cySyncher.destroy();
     cy.destroy();
 
-    res.send({
-      id,
-      url: `${BASE_URL}/document/${id}`
-    });
+    res.send({ id, secret, url: privateUrl, privateUrl, publicUrl });
   } catch(err) {
     next(err);
   }
@@ -56,7 +56,7 @@ const getNetwork = async (exportCy, req, res, next) => {
 
     cy.data({ id });
 
-    const cySyncher = new CytoscapeSyncher(cy, 'secret');
+    const cySyncher = new CytoscapeSyncher(cy);
 
     await cySyncher.load();
 

--- a/src/server/routes/api/document.js
+++ b/src/server/routes/api/document.js
@@ -24,7 +24,7 @@ const postNetwork = async (importBody, req, res, next) => {
     const cy = new Cytoscape();
     const secret = uuid();
     const publicUrl = `${BASE_URL}/document/${id}`;
-    const privateUrl = `${publicUrl}/secret`;
+    const privateUrl = `${publicUrl}/${secret}`;
 
     importBody(cy, body);
     cy.data({ id });

--- a/src/server/secrets.js
+++ b/src/server/secrets.js
@@ -1,0 +1,67 @@
+import PouchDB  from 'pouchdb';
+import { COUCHDB_URL } from './env';
+
+const secretsDb = new PouchDB(`${COUCHDB_URL}/secrets`);
+
+// whitelist of non-secret-protected couchdb ops (HTTP GET always whitelisted)
+const readOps = new Set(['_bulk_get', '_all_docs', '_revs_diff']);
+
+const isReadOp = (req, op) => req.method === 'GET' || readOps.has(op);
+const isWriteOp = (req, op) => !isReadOp(req, op);
+
+const handleSecrets = async (req, res, op, next) => {
+  next(new Error(`Access to secret data is restricted`));
+};
+
+const handleDoc = async (req, res, docId, op, next) => {
+  try {
+    const specifiedSecret = req.get('X-Secret');
+
+    // no writing to doc unless the proper secret is provided
+    if (isWriteOp(req, op)) {
+      let storedSecret;
+      
+      try {
+        const storedSecretRes = await secretsDb.get(docId);
+
+        storedSecret = storedSecretRes.secret;
+      } catch(err) {
+        // no secret => new doc => store secret
+        await secretsDb.put({ _id: docId, secret: specifiedSecret });
+
+        storedSecret = specifiedSecret;
+      }
+
+      if (specifiedSecret !== storedSecret) {
+        throw new Error(`Secret mismatch`);
+      }
+    }
+  } catch (err) {
+    next(err);
+  }
+
+  next();
+};
+
+export function secrets(req, res, next) {
+  const url = req.originalUrl;
+  const urlSplit = url.split('/');
+  const isSecretUrl = urlSplit[2] === 'secrets';
+  const isDocUrl = !isSecretUrl;
+  const docId = isDocUrl ? urlSplit[2] : null;
+  const op = urlSplit[3] || null;
+
+  try {
+    if (isSecretUrl) {
+      handleSecrets(req, res, op, next);
+    } else if (isDocUrl) {
+      handleDoc(req, res, docId, op, next);
+    } else {
+      next();
+    }
+  } catch (err) {
+    next(err);
+  }
+}
+
+export default secrets;

--- a/src/server/secrets.js
+++ b/src/server/secrets.js
@@ -58,7 +58,9 @@ export function secrets(req, res, next) {
     } else if (isDocUrl) {
       handleDoc(req, res, docId, op, next);
     } else {
-      next();
+      const err = Error('Users do not have access to non-document data in the DB');
+
+      next(err);
     }
   } catch (err) {
     next(err);


### PR DESCRIPTION
- HTTP requests to `/db/*` are handled with secrets middleware before being handed off to the HTTP proxy (to CouchDB).
- The secrets middleware forbids writes to the DB if the correct secret is not specified.  If the middleware throws an exception due to an incorrect secret, the middleware passes `next(err)` to stop the progression to the proxy.
- Secrets are stored in the `secrets` DB in CouchDB.
- The secret is specified to PouchDB (and in HTTP requests) via the `X-Secret` HTTP header.
- The demo document always uses the ID `demo` and secret `demo`.
- Allow `COUCHDB_USER` and `COUCHDB_PASSWORD` to be set as environment variables for CouchDB server auth.  This allows us to use CouchDB in non-admin-party mode, as in v3.  If `USE_COUCH_AUTH` is unset or false, then server assumes CouchDB is in party mode (e.g. for local dev.)
- Updates README with new env vars.