### PR TITLE
Feature/undo

### DIFF
--- a/src/client/components/layout/layout-panel.js
+++ b/src/client/components/layout/layout-panel.js
@@ -50,8 +50,19 @@ export class LayoutPanel extends Component {
         options = this.controller.getLayoutOptions(name);
       }
       
+      if(!this.positionSnapshot) {
+        this.positionSnapshot = this.controller.getNodePositionsSnapshot();
+      }
+
       this.applyLayout(options);
     }
+  }
+
+  componentWillUnmount() {
+    if(this.positionSnapshot) {
+      this.controller.postLayoutUndoEdit(this.positionSnapshot);
+    }
+    this.positionSnapshot = null;
   }
 
   handleOptionsChange(options) {

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -2,6 +2,7 @@ import EventEmitter from 'eventemitter3';
 import { styleFactory, LinearColorStyleValue, LinearNumberStyleValue, NumberStyleStruct, ColorStyleStruct } from '../../../model/style'; // eslint-disable-line
 import { CytoscapeSyncher } from '../../../model/cytoscape-syncher'; // eslint-disable-line
 import { NetworkAnalyser } from './network-analyser';
+import { UndoSupport } from '../undo/undo';
 import Cytoscape from 'cytoscape'; // eslint-disable-line
 import Color from 'color'; // eslint-disable-line
 import { VizMapper } from '../../../model/vizmapper'; //eslint-disable-line
@@ -40,9 +41,12 @@ export class NetworkEditorController {
     /** @type {NetworkAnalyser} */
     this.networkAnalyser = new NetworkAnalyser(cy, bus);
 
+    /** @type {UndoSupport} */
+    this.undoSupport = new UndoSupport(bus);
+
     this.drawModeEnabled = false;
 
-    // Save the last used layout options
+    // Save the last used layout optionst
     this.layoutOptions = {
       fcose: {
         name: 'fcose',
@@ -188,6 +192,12 @@ export class NetworkEditorController {
     });
 
     this.bus.emit('addNode', node);
+
+    this.undoSupport.post({
+      title: 'Add Node',
+      undo: () => this.cy.remove(node),
+      redo: () => this.cy.add(node)
+    });
   }
 
   /**

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -84,13 +84,19 @@ export class NetworkEditorController {
   
     const addEle = (ele) => {
       this.undoSupport.post({
-        title: (ele.isNode() ? "Add Node" : "Add Edge") + " (from syncher)",
+        title: (ele.isNode() ? "Add Node" : "Add Edge") + " (remote)",
+        tag: 'sync-add',
         undo: () => ele.cy().remove(ele),
         redo: () => ele.cy().add(ele)
-      });
+      }, true);
     };
   
     this.cySyncher.emitter.on('add', addEle);
+
+    // this.cySyncher.emitter.on('add',    () => console.log('syncher: add'));
+    // this.cySyncher.emitter.on('remove', () => console.log('syncher: remove'));
+    // this.cySyncher.emitter.on('ele',    () => console.log('syncher: ele'));  // move
+    // this.cySyncher.emitter.on('cy',     () => console.log('syncher: cy'));  // style changes, and bypass 
   }
 
   /**
@@ -234,9 +240,9 @@ export class NetworkEditorController {
     });
 
     this.undoSupport.post({
-      title: "Add Node ",
+      title: 'Add Node',
       undo: () => this.cy.remove(node),
-      redo: () => this.cy.add(node),
+      redo: () => this.cy.add(node)
     });
 
     this.bus.emit('addNode', node);

--- a/src/client/components/network-editor/tool-panel.js
+++ b/src/client/components/network-editor/tool-panel.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import EventEmitterProxy from '../../../model/event-emitter-proxy';
 import PropTypes from 'prop-types';
 import { NetworkEditorController } from './controller';
+import { UndoButton } from '../undo/undo-button';
 import Tooltip from '@material-ui/core/Tooltip';
 import { IconButton, Divider } from '@material-ui/core';
 
@@ -59,6 +60,8 @@ export class ToolPanel extends Component {
             <i className="material-icons">delete_forever</i>
           </IconButton>
         </Tooltip>
+        <UndoButton type='undo' icon='undo' title='Undo' controller={controller} />
+        <UndoButton type='redo' icon='redo' title='Redo' controller={controller} />
       </div>
     );
   }

--- a/src/client/components/network-editor/tool-panel.js
+++ b/src/client/components/network-editor/tool-panel.js
@@ -54,10 +54,15 @@ export class ToolPanel extends Component {
             <i className="material-icons icon-rot-330">call_made</i>
           </IconButton>
         </Tooltip>
-        <Divider style={{height: '1px', marginTop: '0.25em', marginBottom: '0.25em'}} flexItem />
         <Tooltip arrow placement="right" title="Delete selected">
           <IconButton size="small" color="inherit" onClick={() => controller.deletedSelectedElements()}>
             <i className="material-icons">delete_forever</i>
+          </IconButton>
+        </Tooltip>
+        <Divider style={{height: '1px', marginTop: '0.25em', marginBottom: '0.25em'}} flexItem />
+        <Tooltip arrow placement="right" title="Fit Network">
+          <IconButton size="small" color="inherit" onClick={() => controller.cy.fit()}>
+            <i className="material-icons">fit_screen</i>
           </IconButton>
         </Tooltip>
         <UndoButton type='undo' icon='undo' title='Undo' controller={controller} />

--- a/src/client/components/style/style-picker-button.js
+++ b/src/client/components/style/style-picker-button.js
@@ -30,12 +30,17 @@ export class StylePickerButton extends Component  {
     this.handleTootlipClose();
   }
 
+  handlePopoverHide(ref) {
+    ref.current.onHide && ref.current.onHide();
+  }
+
   render() {
     const ref = React.createRef();
     return (
       <div>
         <TippyPopover
           onShow={() => this.handlePopoverShow(ref)}
+          onHide={() => this.handlePopoverHide(ref)}
           content={
             <StylePicker ref={ref} {...this.props} />
           }

--- a/src/client/components/style/style-picker.js
+++ b/src/client/components/style/style-picker.js
@@ -45,21 +45,33 @@ export class StylePicker extends React.Component {
   onHide() {
     const vizmapper = this.controller.vizmapper;
 
-    const styleBefore = this.styleSnapshot;
-    const styleAfter = vizmapper.getStyleSnapshot();
-
-    if(!_.isEqual(styleBefore, styleAfter)) {
-      this.controller.undoSupport.post({
-        title: this.props.title,
-        undo: () => vizmapper.setStyleSnapshot(styleBefore),
-        redo: () => vizmapper.setStyleSnapshot(styleAfter)
-      });
+    if(this.state.tab === TAB.BYPASSING) {
+      const styleBefore = this.bypassSnapshot;
+      const styleAfter = vizmapper.getBypassSnapshot();
+      if(!_.isEqual(styleBefore, styleAfter)) {
+        this.controller.undoSupport.post({
+          title: `${this.props.title} (${this.state.numSelected} ${this.getBypassElementLabel()})`,
+          undo: () => vizmapper.setBypassSnapshot(styleBefore),
+          redo: () => vizmapper.setBypassSnapshot(styleAfter)
+        });
+      }
+    } else {
+      const styleBefore = this.styleSnapshot;
+      const styleAfter = vizmapper.getStyleSnapshot();
+      if(!_.isEqual(styleBefore, styleAfter)) {
+        this.controller.undoSupport.post({
+          title: this.props.title,
+          undo: () => vizmapper.setStyleSnapshot(styleBefore),
+          redo: () => vizmapper.setStyleSnapshot(styleAfter)
+        });
+      }
     }
   }
 
 
   onShow() {
     this.styleSnapshot = this.controller.vizmapper.getStyleSnapshot();
+    this.bypassSnapshot = this.controller.vizmapper.getBypassSnapshot();
 
     this.setState({ initialized: true });
     const numSelected = this.controller.bypassCount(this.props.selector);
@@ -177,18 +189,24 @@ export class StylePicker extends React.Component {
     );
   }
 
+  getBypassElementLabel() {
+    const { numSelected } = this.state;
+    const { selector } = this.props;
+    return numSelected == 1
+      ? selector == 'node' ? "node" : "edge"
+      : selector == 'node' ? "nodes" : "edges";
+  }
+
   renderBypass() {
     const { numSelected } = this.state;
-    const element = numSelected == 1
-      ? this.props.selector == 'node' ? "node" : "edge"
-      : this.props.selector == 'node' ? "nodes" : "edges";
+    const elementLabel = this.getBypassElementLabel();
 
     return (
       <div className="style-picker">
         <Paper>
           { this.renderHeader() }
           <div>
-            Setting style bypass for {numSelected} selected {element}
+            Setting style bypass for {numSelected} selected {elementLabel}
           </div>
         </Paper>
         { this.renderSubComponentValue() }

--- a/src/client/components/style/style-picker.js
+++ b/src/client/components/style/style-picker.js
@@ -9,6 +9,7 @@ import FormatListNumberedIcon from '@material-ui/icons/FormatListNumbered';
 import TrendingUpIcon from '@material-ui/icons/TrendingUp';
 import AttributeSelect from '../network-editor/attribute-select';
 import { MAPPING } from '../../../model/style';
+import _ from 'lodash';
 
 
 const TAB = {
@@ -41,7 +42,25 @@ export class StylePicker extends React.Component {
   }
 
 
+  onHide() {
+    const vizmapper = this.controller.vizmapper;
+
+    const styleBefore = this.styleSnapshot;
+    const styleAfter = vizmapper.getStyleSnapshot();
+
+    if(!_.isEqual(styleBefore, styleAfter)) {
+      this.controller.undoSupport.post({
+        title: this.props.title,
+        undo: () => vizmapper.setStyleSnapshot(styleBefore),
+        redo: () => vizmapper.setStyleSnapshot(styleAfter)
+      });
+    }
+  }
+
+
   onShow() {
+    this.styleSnapshot = this.controller.vizmapper.getStyleSnapshot();
+
     this.setState({ initialized: true });
     const numSelected = this.controller.bypassCount(this.props.selector);
 

--- a/src/client/components/undo/undo-button.js
+++ b/src/client/components/undo/undo-button.js
@@ -40,14 +40,16 @@ export class UndoButton extends Component  {
         placement="right" 
         title={this.getButtonTooltip()}
       >
-        <IconButton 
-          size="small" 
-          color="inherit" 
-          disabled={this.state.disabled}
-          onClick={() => this.run()}
-        >
-          <i className="material-icons">{this.props.icon}</i>
-        </IconButton>
+        <span>
+          <IconButton 
+            size="small" 
+            color="inherit" 
+            disabled={this.state.disabled}
+            onClick={() => this.run()}
+          >
+            <i className="material-icons">{this.props.icon}</i>
+          </IconButton>
+        </span>
       </Tooltip>
     );
   }
@@ -58,7 +60,7 @@ UndoButton.propTypes = {
   controller: PropTypes.instanceOf(NetworkEditorController),
   icon: PropTypes.string,
   title: PropTypes.string,
-  type: PropTypes.oneOf('undo', 'redo')
+  type: PropTypes.oneOf(['undo', 'redo'])
 };
 
 export default UndoButton;

--- a/src/client/components/undo/undo-button.js
+++ b/src/client/components/undo/undo-button.js
@@ -1,0 +1,64 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip, IconButton } from '@material-ui/core';
+import { NetworkEditorController } from '../network-editor/controller';
+
+export class UndoButton extends Component  {
+
+  constructor(props) {
+    super(props);
+    this.undoSupport = props.controller.undoSupport;
+
+    props.controller.bus.on('undo', () => this.update());
+
+    this.state = {
+      disabled: !this.undoSupport.has(props.type)
+    };
+  }
+
+  update() {
+    this.setState({ 
+      disabled: !this.undoSupport.has(this.props.type)
+    });
+  }
+
+  run() {
+    this.undoSupport.run(this.props.type);
+  }
+
+  getButtonTooltip() {
+    if(this.state.disabled)
+      return this.props.title;
+    else
+      return this.props.title + ': ' + this.undoSupport.title(this.props.type);
+  }
+
+  render() {
+    return(
+      <Tooltip 
+        arrow 
+        placement="right" 
+        title={this.getButtonTooltip()}
+      >
+        <IconButton 
+          size="small" 
+          color="inherit" 
+          disabled={this.state.disabled}
+          onClick={() => this.run()}
+        >
+          <i className="material-icons">{this.props.icon}</i>
+        </IconButton>
+      </Tooltip>
+    );
+  }
+
+}
+
+UndoButton.propTypes = {
+  controller: PropTypes.instanceOf(NetworkEditorController),
+  icon: PropTypes.string,
+  title: PropTypes.string,
+  type: PropTypes.oneOf('undo', 'redo')
+};
+
+export default UndoButton;

--- a/src/client/components/undo/undo.js
+++ b/src/client/components/undo/undo.js
@@ -1,4 +1,6 @@
 
+const MAX_DEPTH = 25;
+
 export class UndoSupport {
 
   constructor(controller) {
@@ -14,6 +16,9 @@ export class UndoSupport {
   post(edit) {
     console.log("Undo Edit Posted: " + edit.title);
     this.stacks.undo.push(edit);
+    if(this.stacks.undo.length >= MAX_DEPTH) {
+      this.stacks.undo = this.stacks.undo.slice(1);
+    }
     this.stacks.redo = [];
     this.bus.emit('undo', 'post');
   }

--- a/src/client/components/undo/undo.js
+++ b/src/client/components/undo/undo.js
@@ -29,8 +29,6 @@ export class UndoSupport {
   }
 
   post(edit, coalesce = false) {
-    console.log("Undo Edit Posted: " + edit.title);
-
     if(coalesce 
       && this.stacks.undo.length > 0 
       && edit.tag !== undefined 
@@ -48,6 +46,12 @@ export class UndoSupport {
 
     this.stacks.redo = [];
     this.bus.emit('undo', 'post');
+  }
+
+  invalidate() {
+    this.stacks.undo = [];
+    this.stacks.redo = [];
+    this.bus.emit('undo', 'invalidate');
   }
 
   run(type = 'undo') {

--- a/src/client/components/undo/undo.js
+++ b/src/client/components/undo/undo.js
@@ -1,0 +1,57 @@
+export class UndoSupport {
+
+  constructor(bus) {
+    /** @type {EventEmitter} */
+    this.bus = bus;
+
+    this.stacks = {
+      undo: [],
+      redo: []
+    };
+  }
+
+  post(edit) {
+    this.stacks.undo.push(edit);
+    this.stacks.redo = [];
+    this.bus.emit('undo', 'post');
+  }
+
+  run(type = 'undo') {
+    if(type === 'undo')
+      this.undo();
+    else if(type === 'redo')
+      this.redo();
+  }
+
+  undo() {
+    if(this.has('undo')) {
+      const edit = this.stacks.undo.pop();
+      this.stacks.redo.push(edit);
+      edit.undo();
+      this.bus.emit('undo', 'undo');
+    }
+  }
+
+  redo() {
+    if(this.has('redo')) {
+      const edit = this.stacks.redo.pop();
+      this.stacks.undo.push(edit);
+      edit.redo();
+      this.bus.emit('undo', 'redo');
+    }
+  }
+
+  has(type = 'undo') {
+    return this.stacks[type].length > 0;
+  }
+
+  title(type = 'undo') {
+    if(this.has(type)) {
+      const stack = this.stacks[type];
+      return stack[stack.length-1].title;
+    }
+  }
+
+}
+
+export default UndoSupport;

--- a/src/client/components/undo/undo.js
+++ b/src/client/components/undo/undo.js
@@ -1,8 +1,9 @@
+
 export class UndoSupport {
 
-  constructor(bus) {
+  constructor(controller) {
     /** @type {EventEmitter} */
-    this.bus = bus;
+    this.bus = controller.bus;
 
     this.stacks = {
       undo: [],
@@ -11,6 +12,7 @@ export class UndoSupport {
   }
 
   post(edit) {
+    console.log("Undo Edit Posted: " + edit.title);
     this.stacks.undo.push(edit);
     this.stacks.redo = [];
     this.bus.emit('undo', 'post');

--- a/src/model/vizmapper.js
+++ b/src/model/vizmapper.js
@@ -99,6 +99,25 @@ export class VizMapper {
     this.cySyncher.resetStyle();
   }
   
+  // For use by the undo stack
+  getStyleSnapshot() {
+    const _styles = this.cy.data('_styles') || {};
+    return _.cloneDeep(_styles);
+  }
+
+  getBypassSnapshot() {
+    const _bypasses = this.cy.data('_bypasses') || {};
+    return _.cloneDeep(_bypasses);
+  }
+
+  setStyleSnapshot(_styles) {
+    this.cy.data({ _styles });
+  }
+
+  setBypassSnapshot(_bypasses) {
+    this.cy.data({ _bypasses });
+  }
+
   /**
    * Set a global style
    * @param {String} selector A selector of elements on which style is applied ('node' or 'edge')
@@ -113,7 +132,6 @@ export class VizMapper {
     const _styles = this.cy.data('_styles') || {};
 
     _.set(_styles, [selector, property], value);
-
     this.cy.data({ _styles });
 
     this.cy.emit('vmstyle', selector, property, value);
@@ -187,8 +205,8 @@ export class VizMapper {
       }
 
       const _bypasses = this.cy.data('_bypasses') || {};
-      const ids = eles.map(ele => ele.id());
 
+      const ids = eles.map(ele => ele.id());
       if(value === null)
         ids.forEach(id => _.unset(_bypasses, [id, property]));
       else


### PR DESCRIPTION
This feature adds very basic support for undo.
* Adds buttons for "undo" and "redo" to the vertical toolbar.
* Adds a button for "fit network" to the vertical toolbar.
* The undo stack is local to a browser tab. If any remote change comes in over the syncher then the local undo stack is invalidated. No attempt is made to reconcile the undo state between two browser tabs open on the same network.