### PR TITLE
Add PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,26 @@
+**General information**
+
+Associated issues: #X, #Y, #Z
+
+**Checklist**
+
+Author:
+
+- [ ] One or more reviewers have been assigned.
+- [ ] At least one automated test has been included in this pull request to validate that the issue has been fixed, if possible.  If an automated test is not pragmatic, include a screenshot or video demonstrating the fix.
+- [ ] The associated GitHub issues are included (above).
+- [ ] Notes have been included (below).
+
+Reviewers:
+
+- [ ] All automated checks are passing (green check next to latest commit).
+- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.
+
+
+**Notes**
+
+_Notes re. the content of the pull request that would give context to reviewers or serve as a  general record of the changes made.  Add a screenshot or video to demonstrate your fix, if possible._
+
+- This PR adds this.
+- This PR does that.
+- This PR allows us to do some other thing.

--- a/.github/PULL_REQUEST_TEMPLATE/feature_implementation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_implementation.md
@@ -1,0 +1,26 @@
+**General information**
+
+Associated issues: #X, #Y, #Z
+
+**Checklist**
+
+Author:
+
+- [ ] One or more reviewers have been assigned.
+- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s).
+- [ ] The associated GitHub issues are included (above).
+- [ ] Notes have been included (below).
+
+Reviewers:
+
+- [ ] All automated checks are passing (green check next to latest commit).
+- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.
+
+
+**Notes**
+
+_Notes re. the content of the pull request that would give context to reviewers or serve as a  general record of the changes made.  Add a screenshot or video to demonstrate your new feature(s), if possible._
+
+- This PR adds this.
+- This PR does that.
+- This PR allows us to do some other thing.


### PR DESCRIPTION
_This PR adds support for PR templates.  I'm using the template for this PR as a demonstration._

---

**General information**

Associated issues: N/A (normally there would be at least one here)

_Notes re. the content of the pull request that would give context to reviewers or serve as a  general record of the changes made.  Add a screenshot or video to demonstrate your new feature(s), if possible._

- This PR adds support for pull request templates.
- There is one template for bug fix PRs and one for new features.
- When creating a new PR, you can select which template to use and the PR text will mostly be filled out for you.  You just have to fill in the blanks and then tick the appropriate boxes as an author or as a reviewer.

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s). -- N/A
- [x] The associated GitHub issues are included (above). -- N/A
- [x] Notes have been included (below).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.
