### PR TITLE
Fix/ndex import form fixes

### DIFF
--- a/src/client/components/network-editor/header.js
+++ b/src/client/components/network-editor/header.js
@@ -27,6 +27,7 @@ import Cy3NetworkImportDialog from '../network-import/cy3-network-import-dialog'
 import NDExNetworkImportDialog from '../network-import/ndex-network-import-dialog';
 import ImportWizard from '../network-import/import-wizard';
 import { UndoButton } from '../undo/undo-button';
+import AccountButton from './google-login/AccountButton';
 
 
 /**

--- a/src/client/components/network-import/ndex-import-wizard.js
+++ b/src/client/components/network-import/ndex-import-wizard.js
@@ -182,14 +182,17 @@ export class NDExImportSubWizard extends React.Component {
 
   renderSearchBox() {
     let searchString = "";
-    const runSearch = () => {
+    const runSearch = (event) => {
+      event.preventDefault();
       this.setState({ loading: true });
       this.updateButtons( { ...this.state, loading: true });
       this.fetchSearchResults(searchString);
     };
+
     return (
-      <Paper component="form" style={{padding: '2px 4px', display: 'flex', alignItems: 'center', width: '100%'}}>
+      <Paper component="form" onSubmit={runSearch} style={{padding: '2px 4px', display: 'flex', alignItems: 'center', width: '100%'}}>
         <InputBase
+          autoFocus={true}
           style={{marginLeft: '5px', flex: 1 }}
           placeholder="Search NDEx"
           inputProps={{ 'aria-label': 'search google maps' }}


### PR DESCRIPTION
refs #85 

- re-adds missing import for the Google AccountButton component
- when a user presses the enter key, it will now execute fetching the NDEx search results instead of refreshing the page and do nothing
- autofocus the NDEx search input on first render 