### PR TITLE
Miscellaneous fixes re. label mappings & CX routes

### DIFF
--- a/src/server/routes/api/document.js
+++ b/src/server/routes/api/document.js
@@ -178,12 +178,25 @@ http.get('/json/:id', async function(req, res, next){
 });
 
 /**
+ * Create a new network from CX
+ */
+ http.post('/cx', async function(req, res, next) {
+  await postCX2Network(importCX, req, res, next);
+});
+
+/**
+ * Get a network document in CX format
+ */
+http.get('/cx/:id', async function(req, res, next){
+  await getNetwork(exportCX, req, res, next);
+});
+
+/**
  * Import a CX network from NDEx by NDEx UUID
  */
 http.post('/cx-import', async function(req, res, next) {
   await importNDExNetworkById(req, res, next);
 });
-
 
 /**
  * Export a Cytoscape Explore network to NDEx by Cytoscape Explore UUID


### PR DESCRIPTION
- create a default name attribute for every node created in the network editor
- re add export/import cx server endpoints

**General information**

### Add a name attribute to every created 
NODE_STYLE_DEFAULTS have a passthrough mapping for node labels, using the `name` attribute, accessed by `node.data('name')`.  [See here](https://github.com/cytoscape/cytoscape-explore/blob/master/src/model/style.js#L524)
The network editor does not instantiate any nodes with a `name` field.  When the network is exported to CX, there will be a default label mapping to the `name` attribute but no node will have a `name` field.  

This edit changes the controller logic to instantiate every node created in the network editor with a `name` attribute and a default value of empty string.

### Re-add deleted cx import/export API endpoints
I also re-added the endpoints that I deleted before that allow import/export via the node API.



**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.

