### PR TITLE
Fix/support node label position in cx2 export

### DIFF
--- a/src/model/import-export/cx/cx-export-new
+++ b/src/model/import-export/cx/cx-export-new
@@ -1,0 +1,276 @@
+import _ from 'lodash';
+import {
+  rgbObjToHex,
+  MAPPING,
+  STYLE_TYPE,
+  NODE_SELECTOR,
+  EDGE_SELECTOR,
+  DEFAULT_NODE_STYLE,
+  DEFAULT_EDGE_STYLE
+} from '../../style';
+
+export const supportedCXVisualProperties = {
+  NODE_SHAPE: {
+    cyJsName: 'shape',
+    group: 'node',
+    isNestedCXVP: false
+  },
+  NODE_BORDER_WIDTH: {
+    cyJsName: 'border-width',
+    group: 'node',
+    isNestedCXVP: false
+  },
+  NODE_BORDER_COLOR: {
+    cyJsName: 'border-color',
+    group: 'node',
+    isNestedCXVP: false
+  },
+  NODE_LABEL: {
+    cyJsName: 'label',
+    group: 'node',
+    isNestedCXVP: false
+  },
+  NODE_HEIGHT: {
+    cyJsName: 'height',
+    group: 'node',
+    isNestedCXVP: false
+  },
+  NODE_WIDTH: {
+    cyJsName: 'width',
+    group: 'node',
+    isNestedCXVP: false
+  },
+  NODE_BACKGROUND_COLOR: {
+    cyJsName: 'background-color',
+    group: 'node',
+    isNestedCXVP: false
+  },
+  NODE_LABEL_POSITION: {
+    nestedCXVPs: {
+      HORIZONTAL_ANCHOR: {
+        cyJsName: 'text-halign',
+        group: 'node',
+        isNestedCXVP: false
+      },
+      VERTICAL_ANCHOR: {
+        cyJsName: 'text-halign',
+        group: 'node',
+        isNestedCXVP: false
+      },
+      VERTICAL_ALIGN: {
+        cyJsName: null,
+        group: 'node',
+        isNestedCXVP: false
+      },
+      HORIZONTAL_ALIGN: {
+        cyJsName: null,
+        group: 'node',
+        isNestedCXVP: false
+      }
+    },
+    group: 'node',
+    isNestedCXVP: true
+  },
+  NODE_LABEL_COLOR: {
+    cyJsName: 'color',
+    group: 'node',
+    isNestedCXVP: false
+  },
+  NODE_LABEL_FONT_SIZE: {
+    cyJsName: 'font-size',
+    group: 'node',
+    isNestedCXVP: false
+  },
+  EDGE_LINE_STYLE: {
+    cyJsName: 'line-style',
+    group: 'edge',
+    isNestedCXVP: false
+  },
+  EDGE_TARGET_ARROW_COLOR: {
+    cyJsName: 'target-arrow-color',
+    group: 'edge',
+    isNestedCXVP: false
+  },
+  EDGE_TARGET_ARROW_SHAPE: {
+    cyJsName: 'target-arrow-shape',
+    group: 'edge',
+    isNestedCXVP: false
+  },
+  EDGE_SOURCE_ARROW_COLOR: {
+    cyJsName: 'source-arrow-color',
+    group: 'edge',
+    isNestedCXVP: false
+  },
+  EDGE_SOURCE_ARROW_SHAPE: {
+    cyJsName: 'source-arrow-shape',
+    group: 'edge',
+    isNestedCXVP: false
+  },
+  EDGE_LINE_WIDTH: {
+    cyJsName: 'width',
+    group: 'edge',
+    isNestedCXVP: false
+  },
+  EDGE_LINE_COLOR: {
+    cyJsName: 'line-color',
+    group: 'edge',
+    isNestedCXVP: false
+  },
+};
+
+export const getCXValue = ({type, value}) => type === STYLE_TYPE.COLOR ? rgbObjToHex(value) : value;
+
+export const valueMapperConverter = (cxVPInfo, styleSnapShot, visualPropertiesAspect) => {
+  const { group, cxVPName, isNested, nestedCXVPs, cyJsName} = cxVPInfo;
+  const { type, value, mapping } = styleSnapShot[group][cyJsName];
+  console.assert(mapping === MAPPING.VALUE);
+
+  visualPropertiesAspect.visualProperties[0].default[group][cxVPName] = getCXValue({type, value});
+
+  return visualPropertiesAspect;
+};
+
+export const dependantMapperConverter = (cxVPInfo, styleSnapShot, visualPropertiesAspect) => {
+  const { group, cxVPName, isNested, nestedCXVPs, cyJsName } = cxVPInfo;
+  const { value, mapping } = styleSnapShot[group][cyJsName];
+  const { property, multiplier } = value;
+  const dependantStyleObj = styleSnapShot[group][property];
+
+  console.assert(mapping === MAPPING.DEPENDANT);
+  console.log(dependantStyleObj);
+  visualPropertiesAspect.visualProperties[0].default[group][cxVPName] = getCXValue(dependantStyleObj) * multiplier;
+
+  return visualPropertiesAspect;
+};
+
+export const passthroughMapperConverter = (cxVPInfo, styleSnapShot, visualPropertiesAspect) => {
+  const { group, cxVPName, isNested, nestedCXVPs, cyJsName} = cxVPInfo;
+  const { value, mapping, stringValue } = styleSnapShot[group][cyJsName];
+  const { data } = value;
+  const isNode = group === 'node';
+
+  console.assert(mapping === MAPPING.PASSTHROUGH);
+
+  visualPropertiesAspect.visualProperties[0][isNode ? 'nodeMapping' : 'edgeMapping'][cxVPName] = {
+    type: mapping,
+    definition: {
+      attribute: data,
+      selector: stringValue
+    }
+  };
+
+  return visualPropertiesAspect;
+};
+
+export const discreteMapperConverter = (cxVPInfo, styleSnapShot, visualPropertiesAspect) => {
+  const { group, cxVPName, isNested, nestedCXVPs, cyJsName} = cxVPInfo;
+  const { type, value, mapping } = styleSnapShot[group][cyJsName];
+  const { data, defaultValue, styleValues } = value;
+  const isNode = group === 'node';
+  console.log(cxVPInfo, type, value, mapping);
+
+  console.assert(mapping === MAPPING.DISCRETE);
+  visualPropertiesAspect.visualProperties[0].default[group][cxVPName] = getCXValue({type, value: defaultValue});
+  visualPropertiesAspect.visualProperties[0][isNode ? 'nodeMapping' : 'edgeMapping'][cxVPName] = {
+    type: mapping,
+    definition: {
+      attribute: data,
+      map: Object.entries(styleValues).map(([attrClass, attrStyleValue]) => {
+        return {
+          v: attrClass,
+          vp: getCXValue({ type, value: attrStyleValue })
+        };
+      })
+    }
+  };
+
+  return visualPropertiesAspect;
+};
+
+export const linearMapperConverter = (cxVPInfo, styleSnapShot, visualPropertiesAspect) => {
+  const { group, cxVPName, isNested, nestedCXVPs, cyJsName} = cxVPInfo;
+  const { type, value, mapping } = styleSnapShot[group][cyJsName];
+  const { data, dataValues, styleValues } = value;
+  const isNode = group === 'node';
+
+  console.assert(mapping === MAPPING.LINEAR);
+
+  const minVPValue = getCXValue({type, value: styleValues[0]});
+  const maxVPValue = getCXValue({type, value: styleValues[1]});
+
+  visualPropertiesAspect.visualProperties[0][isNode ? 'nodeMapping' : 'edgeMapping'][cxVPName] = {
+    type: 'CONTINUOUS',
+    definition: {
+      attribute: data,
+      map: [{
+        min: dataValues[0],
+        includeMin: true,
+        max: dataValues[1],
+        includeMax: true,
+        minVPValue,
+        maxVPValue
+      }]
+    }
+  };
+
+  return visualPropertiesAspect;
+};
+
+export const converterMap = {
+  [MAPPING.VALUE]: valueMapperConverter,
+  [MAPPING.DEPENDANT]: dependantMapperConverter,
+  [MAPPING.PASSTHROUGH]: passthroughMapperConverter,
+  [MAPPING.DISCRETE]: discreteMapperConverter,
+  [MAPPING.LINEAR]: linearMapperConverter
+};
+
+export const getVisualPropertiesAspect = (cy) => {
+  const styleSnapShot = {
+    [NODE_SELECTOR]: _.cloneDeep(DEFAULT_NODE_STYLE),
+    [EDGE_SELECTOR]: _.cloneDeep(DEFAULT_EDGE_STYLE)
+  };
+  const _styles = _.cloneDeep(cy.data('_styles'));
+  Object.assign(styleSnapShot[NODE_SELECTOR], _styles[NODE_SELECTOR]);
+  Object.assign(styleSnapShot[EDGE_SELECTOR], _styles[EDGE_SELECTOR]);
+
+  const visualPropertiesAspect = {
+    visualProperties: [
+      {
+        default: {
+          network: {
+            NETWORK_BACKGROUND_COLOR: "#FFFFFF"
+          },
+          node: {},
+          edge: {}
+        },
+        nodeMapping: {},
+        edgeMapping: {}
+      }
+    ]
+  };
+
+  Object.entries(supportedCXVisualProperties).forEach(([cxVPName, cxVPInfo]) => {
+    const {group, cyJsName, isNestedCXVP, nestedCXVPs} = cxVPInfo;
+    const styleObj = styleSnapShot[group][cyJsName];
+
+    if(!isNestedCXVP){
+      const { mapping } = styleObj;
+
+      converterMap[mapping]({cxVPName, ...cxVPInfo}, styleSnapShot, visualPropertiesAspect);
+    } else {
+
+    }
+  });
+
+  return visualPropertiesAspect;
+};
+
+const getNodeBypassesAspect = () => {
+
+  return { nodeBypasses: [] };
+};
+
+const getEdgeBypassesAspect = () => {
+
+  return { edgeBypasses: [] };
+};

--- a/src/model/import-export/cx/cx-export-visual-properties.js
+++ b/src/model/import-export/cx/cx-export-visual-properties.js
@@ -6,7 +6,8 @@ import {
   NODE_SELECTOR,
   EDGE_SELECTOR,
   DEFAULT_NODE_STYLE,
-  DEFAULT_EDGE_STYLE
+  DEFAULT_EDGE_STYLE,
+  styleFactory
 } from '../../style';
 
 
@@ -354,7 +355,7 @@ export const baseCXBypassConverter = (cxVPInfo, bypassObj) => {
 
 export const getVisualPropertiesAspect = (cy) => {
   const styleSnapShot = {
-    [NODE_SELECTOR]: _.cloneDeep(DEFAULT_NODE_STYLE),
+    [NODE_SELECTOR]: Object.assign(_.cloneDeep(DEFAULT_NODE_STYLE), { label: styleFactory.string('')}),
     [EDGE_SELECTOR]: _.cloneDeep(DEFAULT_EDGE_STYLE)
   };
   const _styles = _.cloneDeep(cy.data('_styles')) || { [NODE_SELECTOR]: {}, [EDGE_SELECTOR]: {}};
@@ -379,7 +380,6 @@ export const getVisualPropertiesAspect = (cy) => {
 
   Object.entries(supportedCXVisualProperties).forEach(([cxVPName, cxVPInfo]) => {
     const { converter } = cxVPInfo;
-
     // some properties require special conversion functions e.g. nested properties
     // most properties can just use the base conversion function
     if (converter != null){

--- a/src/model/import-export/cx/cx-export-visual-properties.js
+++ b/src/model/import-export/cx/cx-export-visual-properties.js
@@ -78,7 +78,7 @@ export const supportedCXVisualProperties = {
       const defaultLabelPosition = {
         HORIZONTAL_ALIGN: 'center',
         HORIZONTAL_ANCHOR: 'center',
-        JUSTIFCATION: 'center',
+        JUSTIFICATION: 'center',
         MARGIN_X: 0.0,
         MARGIN_Y: 0.0,
         VERTICAL_ALIGN: 'center',
@@ -164,7 +164,7 @@ export const supportedCXVisualProperties = {
       const defaultLabelPosition = {
         HORIZONTAL_ALIGN: 'center',
         HORIZONTAL_ANCHOR: 'center',
-        JUSTIFCATION: 'center',
+        JUSTIFICATION: 'center',
         MARGIN_X: 0.0,
         MARGIN_Y: 0.0,
         VERTICAL_ALIGN: 'center',

--- a/src/model/import-export/cx/cy-converter.js
+++ b/src/model/import-export/cx/cy-converter.js
@@ -2,118 +2,37 @@
  import { rgbObjToHex, MAPPING, STYLE_TYPE, DEFAULT_NODE_STYLE, DEFAULT_EDGE_STYLE } from '../../style';
  import _ from 'lodash';
 
+ import { getVisualPropertiesAspect } from './cx-export-new';
 
- const cxStyleConverter = ({type, value, cxVPName, cxParentVPName}) => {
-  return type === STYLE_TYPE.COLOR ? rgbObjToHex(value) : value;
- };
 
- const cxStyleMutationReducer = (curStyle, nextStyle) => nextStyle;
 
- const cxStyleOverrideReducer = (curStyle, nextStyle) => Object.assign({}, curStyle, nextStyle);
+// get stylesnapshot
+// for every key in default object
+//   populate the snapshot if the key is not found in the snapshot
+//
 
- const CE_2_CX_STYLE_CONVERTING_TABLE = {
-   node: {
-    'shape': {
-      cxVPName: 'NODE_SHAPE',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'border-width': {
-      cxVPName: 'NODE_BORDER_WIDTH',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'border-color': {
-      cxVPName: 'NODE_BORDER_COLOR',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'label': {
-      cxVPName: 'NODE_LABEL',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'height': {
-      cxVPName: 'NODE_HEIGHT',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'width': {
-      cxVPName: 'NODE_WIDTH',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'background-color': {
-      cxVPName: 'NODE_BACKGROUND_COLOR',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'text-halign': {
-      cxVPName: 'HORIZONTAL_ALIGN',
-      cxParentVPName: 'NODE_LABEL_POSITION',
-      converter: cxStyleConverter,
-      reducer: cxStyleOverrideReducer
-    },
-    'text-valign': {
-      cxVPName: 'VERTICAL_ALIGN',
-      cxParentVPName: 'NODE_LABEL_POSITION',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'color': {
-      cxVPName: 'NODE_LABEL_COLOR',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'font-size': {
-      cxVPName: 'NODE_LABEL_FONT_SIZE',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-   },
-   edge: {
-    'line-style': {
-      cxVPName: 'EDGE_LINE_STYLE',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'target-arrow-color': {
-      cxVPName: 'EDGE_TARGET_ARROW_COLOR',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'target-arrow-shape': {
-      cxVPName: 'EDGE_TARGET_ARROW_SHAPE',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'source-arrow-color': {
-      cxVPName: 'EDGE_SOURCE_ARROW_COLOR',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'source-arrow-shape': {
-      cxVPName: 'EDGE_SOURCE_ARROW_SHAPE',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'color': {
-      cxVPName: 'EDGE_LABEL_COLOR',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'width': {
-      cxVPName: 'EDGE_LINE_WIDTH',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-    'line-color': {
-      cxVPName: 'EDGE_LINE_COLOR',
-      converter: cxStyleConverter,
-      reducer: cxStyleMutationReducer
-    },
-   }
- };
+// mapping handlers
+//  make 4 mapping function handlers each with a different type handler
+  // - dependant
+  // - value
+  // - passthrough
+  // - linear
+//  e.g. nested cx name prop logic or simple value logic
+
+// create a table of VP names to CE style names
+// each CX VP has some default values
+ // for each supported VP name, extract CX from corresponding CE default styles
+ // for each supported VP name, extract CX from corresponding CE style snapshot
+ // for each supported VP name, extrat CX from corresponding CE bypass snapshot
+
+// Each supported cx visual property needs:
+// - cxVPName
+  //  - cyJsStyleName
+  //  - group (node/edge)
+  //  - default value
+  //  - cx name
+  //  - isnested
+  //  - cx child names
 
  const cy2cxNodeVisualProp = {
    // cy.js to cx
@@ -294,54 +213,13 @@
  };
 
  export const cxVisualPropertiesAspects = cy => {
-  const visualPropertiesAspect = {
-    visualProperties: [
-      {
-        default: {
-          network: {
-            NETWORK_BACKGROUND_COLOR: "#FFFFFF"
-          },
-          node: {},
-          edge: {}
-        },
-        nodeMapping: {},
-        edgeMapping: {}
-      }
-    ]
-  };
+  const visualPropertiesAspect = getVisualPropertiesAspect(cy);
 
   const nodeBypassesAspect = { nodeBypasses: [] };
   const edgeBypassesAspect = { edgeBypasses: [] };
 
   const styleSnapshot = _.cloneDeep(cy.data('_styles') || {});
   const bypassSnapshot = _.cloneDeep(cy.data('_bypasses') || {});
-
-
-  const defaultVisualProperties = [
-    ...Object.entries(DEFAULT_NODE_STYLE).map(([cyjsVPName, cyjsVPValue]) => {
-     return {
-       group: 'node',
-       cyjsVPName,
-       cyjsVPValue
-     };
-    }),
-    ...Object.entries(DEFAULT_EDGE_STYLE).map(([cyjsVPName, cyjsVPValue]) => {
-     return {
-       group: 'edge',
-       cyjsVPName,
-       cyjsVPValue
-     };
-    })
-  ];
-
-  // defaultVisualProperties.forEach(({group, cyjsVPName, cyjsVPValue}) => {
-  //  let { type, value, mapping } = cyjsVPValue;
-  //  let {cxVPName, cxParentVPName, converter } = CE_2_CX_STYLE_CONVERTING_TABLE[group][cyjsVPName];
-
-  //  // mappings go in the nodeMapping/edgeMapping object
-  //  if(cyjsVPName === 'label' || mapping !== MAPPING.VALUE){
-  //    return;
-  //  }
 
    const validDefaultNodeStyles = _.cloneDeep(DEFAULT_NODE_STYLE);
    const validDefaultEdgeStyles = _.cloneDeep(DEFAULT_EDGE_STYLE);
@@ -354,133 +232,6 @@
    .filter(key => cy2cxEdgeVisualProp[key] == null)
    .forEach(key => delete validDefaultEdgeStyles[key]);
 
-     //  visualPropertiesAspect.visualProperties[0].default[group] = converter(Object.assign({}, cyjsVPValue, cxVPName, cxParentVPName));
-  // });
-
-
-   // 1. populate defaults with the default styles from style.js
-   // 2. iterate over each entry in the style snapshot
-   //      if the mapping type is value, update the visualProperties.default object
-   //      if the mapping is linear/passthrough/discrete
-           //  handle the mappings (TODO)
-             // case linear
-             // case discrete
-             // case passthrough
-   // 3. iterate over the bypasses and update the bypass aspects for nodes and edges
-   // 1. populate style defaults
-   [
-     {
-       defaultStyleDict: validDefaultNodeStyles,
-       defaultAspect: visualPropertiesAspect.visualProperties[0].default.node,
-       cy2cxStyleNameMap: cy2cxNodeVisualProp
-     },
-     {
-       defaultStyleDict: validDefaultEdgeStyles,
-       defaultAspect: visualPropertiesAspect.visualProperties[0].default.edge,
-       cy2cxStyleNameMap: cy2cxEdgeVisualProp
-     }
-   ].forEach(({defaultStyleDict, defaultAspect, cy2cxStyleNameMap}) => {
-     Object.entries(defaultStyleDict).forEach(([cyStyleName, styleObj]) => {
-       let { type, value, mapping } = styleObj;
-       let cxStyleName = cy2cxStyleNameMap[cyStyleName];
-
-       // mappings go in the nodeMapping/edgeMapping object
-       if(cyStyleName === 'label' || mapping !== MAPPING.VALUE){
-         return;
-       }
-       defaultAspect[cxStyleName] = type === STYLE_TYPE.COLOR ? rgbObjToHex(value) : value;
-     });
-   });
-
-   [
-     {
-       styleSnapshot: styleSnapshot.node || {},
-       defaultAspect: visualPropertiesAspect.visualProperties[0].default.node,
-       mappingAspect: visualPropertiesAspect.visualProperties[0].nodeMapping,
-       cy2cxStyleNameMap: cy2cxNodeVisualProp
-     },
-     {
-       styleSnapshot: styleSnapshot.edge || {},
-       defaultAspect: visualPropertiesAspect.visualProperties[0].default.edge,
-       mappingAspect: visualPropertiesAspect.visualProperties[0].edgeMapping,
-       cy2cxStyleNameMap: cy2cxEdgeVisualProp
-     }
-   ].forEach(({styleSnapshot, defaultAspect, mappingAspect, cy2cxStyleNameMap}) => {
-     Object.entries(styleSnapshot || {}).forEach(([cyStyleName, styleObj]) => {
-       let { type, value, mapping, stringValue } = styleObj;
-       let cxStyleName = cy2cxStyleNameMap[cyStyleName];
-       let { data, defaultValue, styleValues, dataValues } = value;
-
-       switch(mapping){
-         case MAPPING.VALUE:
-           defaultAspect[cxStyleName] = type === STYLE_TYPE.COLOR ? rgbObjToHex(value) : value;
-           break;
-         case MAPPING.PASSTHROUGH:
-           mappingAspect[cxStyleName] = {
-             type: mapping,
-             definition: {
-               attribute: data,
-               selector: stringValue
-             }
-           };
-           break;
-         case MAPPING.DISCRETE: {
-          if(cyStyleName === 'text-valign' || cyStyleName === 'text-halign'){
-            defaultAspect[cxStyleName] = cxStyleConverter({type, value: defaultValue});
-            mappingAspect[cxStyleName] = {
-               type: mapping,
-               definition: {
-                 attribute: data,
-                 map: Object.entries(styleValues).map(([attrClass, attrStyleValue]) => {
-                   return {
-                     v: attrClass,
-                     vp: cxStyleConverter({ type, value: attrStyleValue })
-                   };
-                 })
-               }
-             };
-          } else {
-            defaultAspect[cxStyleName] = cxStyleConverter({type, value: defaultValue});
-            mappingAspect[cxStyleName] = {
-               type: mapping,
-               definition: {
-                 attribute: data,
-                 map: Object.entries(styleValues).map(([attrClass, attrStyleValue]) => {
-                   return {
-                     v: attrClass,
-                     vp: cxStyleConverter({ type, value: attrStyleValue })
-                   };
-                 })
-               }
-             };
-          }
-           break;
-         }
-         case MAPPING.LINEAR: {
-           let minVPValue = type === STYLE_TYPE.COLOR ? rgbObjToHex(styleValues[0]) : styleValues[0];
-           let maxVPValue = type === STYLE_TYPE.COLOR ? rgbObjToHex(styleValues[1]) : styleValues[1];
-
-           mappingAspect[cxStyleName] = {
-             type: 'CONTINUOUS',
-             definition: {
-               attribute: data,
-               map: [{
-                 min: dataValues[0],
-                 includeMin: true,
-                 max: dataValues[1],
-                 includeMax: true,
-                 minVPValue,
-                 maxVPValue
-               }]
-             }
-           };
-           break;
-         }
-         default:
-           break;
-       }
-     });
-   });
 
    // 3. bypass handling
    Object.entries(bypassSnapshot).forEach(([cytoscapeExploreId, bypassObj]) => {

--- a/src/model/import-export/cx/cy-converter.js
+++ b/src/model/import-export/cx/cy-converter.js
@@ -2,7 +2,119 @@
  import { rgbObjToHex, MAPPING, STYLE_TYPE, DEFAULT_NODE_STYLE, DEFAULT_EDGE_STYLE } from '../../style';
  import _ from 'lodash';
 
- // current CX node properties supported
+
+ const cxStyleConverter = ({type, value, cxVPName, cxParentVPName}) => {
+  return type === STYLE_TYPE.COLOR ? rgbObjToHex(value) : value;
+ };
+
+ const cxStyleMutationReducer = (curStyle, nextStyle) => nextStyle;
+
+ const cxStyleOverrideReducer = (curStyle, nextStyle) => Object.assign({}, curStyle, nextStyle);
+
+ const CE_2_CX_STYLE_CONVERTING_TABLE = {
+   node: {
+    'shape': {
+      cxVPName: 'NODE_SHAPE',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'border-width': {
+      cxVPName: 'NODE_BORDER_WIDTH',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'border-color': {
+      cxVPName: 'NODE_BORDER_COLOR',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'label': {
+      cxVPName: 'NODE_LABEL',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'height': {
+      cxVPName: 'NODE_HEIGHT',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'width': {
+      cxVPName: 'NODE_WIDTH',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'background-color': {
+      cxVPName: 'NODE_BACKGROUND_COLOR',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'text-halign': {
+      cxVPName: 'HORIZONTAL_ALIGN',
+      cxParentVPName: 'NODE_LABEL_POSITION',
+      converter: cxStyleConverter,
+      reducer: cxStyleOverrideReducer
+    },
+    'text-valign': {
+      cxVPName: 'VERTICAL_ALIGN',
+      cxParentVPName: 'NODE_LABEL_POSITION',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'color': {
+      cxVPName: 'NODE_LABEL_COLOR',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'font-size': {
+      cxVPName: 'NODE_LABEL_FONT_SIZE',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+   },
+   edge: {
+    'line-style': {
+      cxVPName: 'EDGE_LINE_STYLE',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'target-arrow-color': {
+      cxVPName: 'EDGE_TARGET_ARROW_COLOR',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'target-arrow-shape': {
+      cxVPName: 'EDGE_TARGET_ARROW_SHAPE',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'source-arrow-color': {
+      cxVPName: 'EDGE_SOURCE_ARROW_COLOR',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'source-arrow-shape': {
+      cxVPName: 'EDGE_SOURCE_ARROW_SHAPE',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'color': {
+      cxVPName: 'EDGE_LABEL_COLOR',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'width': {
+      cxVPName: 'EDGE_LINE_WIDTH',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+    'line-color': {
+      cxVPName: 'EDGE_LINE_COLOR',
+      converter: cxStyleConverter,
+      reducer: cxStyleMutationReducer
+    },
+   }
+ };
+
  const cy2cxNodeVisualProp = {
    // cy.js to cx
    'shape': 'NODE_SHAPE',
@@ -87,115 +199,149 @@
    return null;
  };
 
- /**
-  * Export a Cytoscape instance to CX2 format
-  * @param {Cytoscape.Core} cy
-  */
- export const convertCY = (cy) => {
-   const cx2Descriptor = {
-     CXVersion: "2.0",
-     hasFragments: false
-   };
+ export const cx2Descriptor = () => ({
+    CXVersion: "2.0",
+    hasFragments: false
+ });
 
-   const nodeAttributes = {
-     cytoscapeExploreId: {
-       d: 'string'
-     }
-   };
-   const edgeAttributes = {
-     cytoscapeExploreId: {
-       d: 'string'
-     }
-   };
-   const cxNodes = [];
-   const cxEdges = [];
+ export const cxDataAspects = (cy) => {
+  const nodeAttributes = {
+    cytoscapeExploreId: {
+      d: 'string'
+    }
+  };
 
-   cy.elements().forEach((ele, index) => {
-     let v = {};
-     let isNode = ele.isNode();
-     ele.scratch('_exportCX2Id', index);
+  const edgeAttributes = {
+    cytoscapeExploreId: {
+      d: 'string'
+    }
+  };
 
-     Object.keys(ele.data()).forEach(key => {
-       let value = ele.data(key);
+  const cxNodes = [];
+  const cxEdges = [];
 
-       if(key !== 'id' && key !== 'source' && key !== 'target') {
-         let type = getCXType(value);
+  cy.elements().forEach((ele, index) => {
+    let v = {};
+    let isNode = ele.isNode();
+    ele.scratch('_exportCX2Id', index);
 
-         // TODO also need to check that the type for each attribute is the same for
-         // each node
-         if(type != null){
-           v[key] = value;
-           let attributeDict = isNode ? nodeAttributes : edgeAttributes;
+    Object.keys(ele.data()).forEach(key => {
+      let value = ele.data(key);
 
-           attributeDict[key] = {
-             d: type
-           };
-         }
-       }
-     });
+      if(key !== 'id' && key !== 'source' && key !== 'target') {
+        let type = getCXType(value);
 
-     if(isNode){
-       cxNodes.push({
-         id: index,
-         x: ele.position('x'),
-         y: ele.position('y'),
-         v
-       });
-     } else {
-       cxEdges.push({
-         id: index,
-         s: ele.source().scratch('_exportCX2Id'),
-         t: ele.target().scratch('_exportCX2Id'),
-         v
-       });
-     }
-   });
+        // TODO also need to check that the type for each attribute is the same for
+        // each node
+        if(type != null){
+          v[key] = value;
+          let attributeDict = isNode ? nodeAttributes : edgeAttributes;
 
-   const attributeDeclarationsAspect = {
-     attributeDeclarations: [{
-       networkAttributes: {
-         name: { d: 'string', v: ''},
-         description: { d: 'string', v: ''},
-         version: { d: 'string', v: ''},
-         cytoscapeExploreId: { d: 'string', v: ''}
-       },
-       nodes: nodeAttributes,
-       edges: edgeAttributes
-     }]
-   };
+          attributeDict[key] = {
+            d: type
+          };
+        }
+      }
+    });
 
-   const networkAttributesAspect = {
-     networkAttributes: [{
-       name: cy.data('name') || 'cyexplore',
-       description: cy.data('description') || 'description',
-       version: cy.data('version') || '1.0'
-     }]
-   };
+    if(isNode){
+      cxNodes.push({
+        id: index,
+        x: ele.position('x'),
+        y: ele.position('y'),
+        v
+      });
+    } else {
+      cxEdges.push({
+        id: index,
+        s: ele.source().scratch('_exportCX2Id'),
+        t: ele.target().scratch('_exportCX2Id'),
+        v
+      });
+    }
+  });
 
-   const nodesAspect = { nodes: cxNodes };
-   const edgesAspect = { edges: cxEdges };
+  const attributeDeclarationsAspect = {
+    attributeDeclarations: [{
+      networkAttributes: {
+        name: { d: 'string', v: ''},
+        description: { d: 'string', v: ''},
+        version: { d: 'string', v: ''},
+        cytoscapeExploreId: { d: 'string', v: ''}
+      },
+      nodes: nodeAttributes,
+      edges: edgeAttributes
+    }]
+  };
 
-   const visualPropertiesAspect = {
-     visualProperties: [
-       {
-         default: {
-           network: {
-             NETWORK_BACKGROUND_COLOR: "#FFFFFF"
-           },
-           node: {},
-           edge: {}
-         },
-         nodeMapping: {},
-         edgeMapping: {}
-       }
-     ]
-   };
+  const networkAttributesAspect = {
+    networkAttributes: [{
+      name: cy.data('name') || 'cyexplore',
+      description: cy.data('description') || 'description',
+      version: cy.data('version') || '1.0'
+    }]
+  };
 
-   const nodeBypassesAspect = { nodeBypasses: [] };
-   const edgeBypassesAspect = { edgeBypasses: [] };
+  const nodesAspect = { nodes: cxNodes };
+  const edgesAspect = { edges: cxEdges };
 
-   const styleSnapshot = _.cloneDeep(cy.data('_styles') || {});
-   const bypassSnapshot = _.cloneDeep(cy.data('_bypasses') || {});
+  return {
+    nodesAspect,
+    edgesAspect,
+    attributeDeclarationsAspect,
+    networkAttributesAspect
+  };
+ };
+
+ export const cxVisualPropertiesAspects = cy => {
+  const visualPropertiesAspect = {
+    visualProperties: [
+      {
+        default: {
+          network: {
+            NETWORK_BACKGROUND_COLOR: "#FFFFFF"
+          },
+          node: {},
+          edge: {}
+        },
+        nodeMapping: {},
+        edgeMapping: {}
+      }
+    ]
+  };
+
+  const nodeBypassesAspect = { nodeBypasses: [] };
+  const edgeBypassesAspect = { edgeBypasses: [] };
+
+  const styleSnapshot = _.cloneDeep(cy.data('_styles') || {});
+  const bypassSnapshot = _.cloneDeep(cy.data('_bypasses') || {});
+
+
+  const defaultVisualProperties = [
+    ...Object.entries(DEFAULT_NODE_STYLE).map(([cyjsVPName, cyjsVPValue]) => {
+     return {
+       group: 'node',
+       cyjsVPName,
+       cyjsVPValue
+     };
+    }),
+    ...Object.entries(DEFAULT_EDGE_STYLE).map(([cyjsVPName, cyjsVPValue]) => {
+     return {
+       group: 'edge',
+       cyjsVPName,
+       cyjsVPValue
+     };
+    })
+  ];
+
+  // defaultVisualProperties.forEach(({group, cyjsVPName, cyjsVPValue}) => {
+  //  let { type, value, mapping } = cyjsVPValue;
+  //  let {cxVPName, cxParentVPName, converter } = CE_2_CX_STYLE_CONVERTING_TABLE[group][cyjsVPName];
+
+  //  // mappings go in the nodeMapping/edgeMapping object
+  //  if(cyjsVPName === 'label' || mapping !== MAPPING.VALUE){
+  //    return;
+  //  }
 
    const validDefaultNodeStyles = _.cloneDeep(DEFAULT_NODE_STYLE);
    const validDefaultEdgeStyles = _.cloneDeep(DEFAULT_EDGE_STYLE);
@@ -207,6 +353,10 @@
    Object.keys(validDefaultEdgeStyles)
    .filter(key => cy2cxEdgeVisualProp[key] == null)
    .forEach(key => delete validDefaultEdgeStyles[key]);
+
+     //  visualPropertiesAspect.visualProperties[0].default[group] = converter(Object.assign({}, cyjsVPValue, cxVPName, cxParentVPName));
+  // });
+
 
    // 1. populate defaults with the default styles from style.js
    // 2. iterate over each entry in the style snapshot
@@ -275,21 +425,35 @@
            };
            break;
          case MAPPING.DISCRETE: {
-           // discrete mappings specify colors as { r, g, b } objects
-           // turn them into strings before updating them in the cx output
-           defaultAspect[cxStyleName] = type === STYLE_TYPE.COLOR ? rgbObjToHex(defaultValue) : defaultValue;
-           mappingAspect[cxStyleName] = {
-             type: mapping,
-             definition: {
-               attribute: data,
-               map: Object.entries(styleValues).map(([attrClass, attrStyleValue]) => {
-                 return {
-                   v: attrClass,
-                   vp: type === STYLE_TYPE.COLOR ? rgbObjToHex(attrStyleValue) : attrStyleValue
-                 };
-               })
-             }
-           };
+          if(cyStyleName === 'text-valign' || cyStyleName === 'text-halign'){
+            defaultAspect[cxStyleName] = cxStyleConverter({type, value: defaultValue});
+            mappingAspect[cxStyleName] = {
+               type: mapping,
+               definition: {
+                 attribute: data,
+                 map: Object.entries(styleValues).map(([attrClass, attrStyleValue]) => {
+                   return {
+                     v: attrClass,
+                     vp: cxStyleConverter({ type, value: attrStyleValue })
+                   };
+                 })
+               }
+             };
+          } else {
+            defaultAspect[cxStyleName] = cxStyleConverter({type, value: defaultValue});
+            mappingAspect[cxStyleName] = {
+               type: mapping,
+               definition: {
+                 attribute: data,
+                 map: Object.entries(styleValues).map(([attrClass, attrStyleValue]) => {
+                   return {
+                     v: attrClass,
+                     vp: cxStyleConverter({ type, value: attrStyleValue })
+                   };
+                 })
+               }
+             };
+          }
            break;
          }
          case MAPPING.LINEAR: {
@@ -344,72 +508,98 @@
      }
    });
 
-   const visualEditorPropertiesAspect = {
-     visualEditorProperties: [
-       {
-         properties: {
-           nodeSizeLocked: false
-         }
-       }
-     ]
+   return {
+    visualPropertiesAspect,
+    nodeBypassesAspect,
+    edgeBypassesAspect
    };
+ };
 
-   const statusAspect = {
-     status: [{
-       error: '',
-       success: true
-     }]
-   };
-   const metadataAspect = {
-     metaData: [
-       {
-         elementCount: attributeDeclarationsAspect.attributeDeclarations.length,
-         name: 'attributeDeclarations'
-       },
-       {
-         elementCount: networkAttributesAspect.networkAttributes.length,
-         name: 'networkAttributes'
-       },
-       {
-         elementCount: nodesAspect.nodes.length,
-         name: 'nodes'
-       },
-       {
-         elementCount: edgesAspect.edges.length,
-         name: 'edges'
-       },
-       {
-         elementCount: visualPropertiesAspect.visualProperties.length,
-         name: 'visualProperties'
-       },
-       {
-         elementCount: nodeBypassesAspect.nodeBypasses.length,
-         name: 'nodeBypasses'
-       },
-       {
-         elementCount: edgeBypassesAspect.edgeBypasses.length,
-         name: 'edgeBypasses'
-       },
-       {
-         elementCount: visualEditorPropertiesAspect.visualEditorProperties.length,
-         name: 'visualEditorProperties'
-       }
-     ]
-   };
+ /**
+  * Export a Cytoscape instance to CX2 format
+  * @param {Cytoscape.Core} cy
+  */
+ export const convertCY = (cy) => {
 
-   const cx2Output = [
-     cx2Descriptor,
-     metadataAspect,
-     attributeDeclarationsAspect,
-     networkAttributesAspect,
-     nodesAspect,
-     edgesAspect,
-     visualPropertiesAspect,
-     nodeBypassesAspect,
-     edgeBypassesAspect,
-     visualEditorPropertiesAspect,
-     statusAspect,
-   ];
+  const {
+    nodesAspect,
+    edgesAspect,
+    attributeDeclarationsAspect,
+    networkAttributesAspect
+  } = cxDataAspects(cy);
 
-   return cx2Output;
+  const {
+    visualPropertiesAspect,
+    nodeBypassesAspect,
+    edgeBypassesAspect
+  } = cxVisualPropertiesAspects(cy);
+
+  const visualEditorPropertiesAspect = {
+    visualEditorProperties: [
+      {
+        properties: {
+          nodeSizeLocked: false
+        }
+      }
+    ]
+  };
+
+  const statusAspect = {
+    status: [{
+      error: '',
+      success: true
+    }]
+  };
+  const metadataAspect = {
+    metaData: [
+      {
+        elementCount: attributeDeclarationsAspect.attributeDeclarations.length,
+        name: 'attributeDeclarations'
+      },
+      {
+        elementCount: networkAttributesAspect.networkAttributes.length,
+        name: 'networkAttributes'
+      },
+      {
+        elementCount: nodesAspect.nodes.length,
+        name: 'nodes'
+      },
+      {
+        elementCount: edgesAspect.edges.length,
+        name: 'edges'
+      },
+      {
+        elementCount: visualPropertiesAspect.visualProperties.length,
+        name: 'visualProperties'
+      },
+      {
+        elementCount: nodeBypassesAspect.nodeBypasses.length,
+        name: 'nodeBypasses'
+      },
+      {
+        elementCount: edgeBypassesAspect.edgeBypasses.length,
+        name: 'edgeBypasses'
+      },
+      {
+        elementCount: visualEditorPropertiesAspect.visualEditorProperties.length,
+        name: 'visualEditorProperties'
+      }
+    ]
+  };
+
+  const cx2Output = [
+    cx2Descriptor(),
+    metadataAspect,
+    attributeDeclarationsAspect,
+    networkAttributesAspect,
+    nodesAspect,
+    edgesAspect,
+    visualPropertiesAspect,
+    nodeBypassesAspect,
+    edgeBypassesAspect,
+    visualEditorPropertiesAspect,
+    statusAspect,
+  ];
+
+  return cx2Output;
  };

--- a/src/model/style.js
+++ b/src/model/style.js
@@ -1,6 +1,9 @@
 import Color from 'color';
 import Cytoscape from 'cytoscape'; // eslint-disable-line
 
+export const NODE_SELECTOR = 'node';
+export const EDGE_SELECTOR = 'edge';
+
 /**
  * @typedef {String} MAPPING
  **/
@@ -498,7 +501,7 @@ export const PROPERTY_TYPE = {
   'text-valign': STYLE_TYPE.STRING,
   'font-size': STYLE_TYPE.NUMBER,
   'opacity': STYLE_TYPE.NUMBER,
-}; 
+};
 
 /**  Supported node style properties  */
 // Note: make sure to add new properties to DEFAULT_NODE_STYLE */
@@ -532,7 +535,7 @@ export const DEFAULT_NODE_STYLE = {
   'opacity': styleFactory.number(1), // This is required to support selection, even if we don't expose it in the UI
 };
 
-// Note, these mapping defaults are hard-coded for now. This is temporary. They correspond to mappings from the UI components. 
+// Note, these mapping defaults are hard-coded for now. This is temporary. They correspond to mappings from the UI components.
 export const DEFAULT_NODE_MAPPING_STYLE_VALUES = {
   'background-color': [{"r":230,"g":179,"b":179}, {"r":153,"g":51,"b":51}], // This is the red gradient from the ColorGradients component.
   'width': [10, 50],
@@ -599,7 +602,7 @@ export const edgeStylePropertyExists = property => {
 export const stylePropertyExists = (property, selector) => {
   if( !selector ){
     return nodeStylePropertyExists(property) || edgeStylePropertyExists(property);
-  } else if( selector === 'node' ){
+  } else if( selector === NODE_SELECTOR ){
     return nodeStylePropertyExists(property);
   } else {
     return edgeStylePropertyExists(property);

--- a/src/model/vizmapper.js
+++ b/src/model/vizmapper.js
@@ -1,14 +1,22 @@
 import { CytoscapeSyncher } from './cytoscape-syncher'; // eslint-disable-line
-import { MAPPING, STYLE_TYPE, NODE_STYLE_PROPERTIES, EDGE_STYLE_PROPERTIES, DEFAULT_NODE_STYLE, DEFAULT_EDGE_STYLE, stylePropertyExists, getFlatStyleForEle, PROPERTY_TYPE } from './style';
+import {
+  MAPPING,
+  NODE_SELECTOR,
+  EDGE_SELECTOR,
+  STYLE_TYPE,
+  NODE_STYLE_PROPERTIES,
+  EDGE_STYLE_PROPERTIES,
+  DEFAULT_NODE_STYLE,
+  DEFAULT_EDGE_STYLE,
+  stylePropertyExists,
+  getFlatStyleForEle,
+  PROPERTY_TYPE } from './style';
 import _ from 'lodash';
 import { EventEmitterProxy } from './event-emitter-proxy';
 
 /**
  * @typedef {import('./style').StyleStruct} StyleStruct
  */
-
-const NODE_SELECTOR = 'node';
-const EDGE_SELECTOR = 'edge';
 
 const log = process.env.LOG_VIZMAPPER === 'true' ? console.log : _.noop;
 
@@ -75,7 +83,7 @@ const assertIsSingleEle = ele => {
 export class VizMapper {
   /**
    * Create a new VizMapper
-   * @param {Cytoscape.Core} cy The Cytoscape instance to style 
+   * @param {Cytoscape.Core} cy The Cytoscape instance to style
    * @param {CytoscapeSyncher} cySyncher The syncher to coordinate saved style with
    */
   constructor(cy, cySyncher){
@@ -98,7 +106,7 @@ export class VizMapper {
   reset(){
     this.cySyncher.resetStyle();
   }
-  
+
   // For use by the undo stack
   getStyleSnapshot() {
     const _styles = this.cy.data('_styles') || {};
@@ -224,7 +232,7 @@ export class VizMapper {
       // assertIsSingleEle(ele);
 
       // The below code creates a map of each style val to the elements
-      // that have that value. With "unset" used as a special key for 
+      // that have that value. With "unset" used as a special key for
       // elements that don't have a bypass.
       // const _bypasses = this.cy.data('_bypasses') || {};
       // // [{value:{r:1,g:1,b:1}, ids:['id1', 'id2']}];
@@ -295,7 +303,7 @@ export class VizMapper {
       flatVal = getFlatStyleForEle(ele, styleStruct);
     }
 
-    // TODO This is temporary, need better support for default styles 
+    // TODO This is temporary, need better support for default styles
     // if a data value falls outside the range of a mapping.
     if(flatVal === undefined || flatVal === null || Number.isNaN(flatVal)) {
       const DEF_STYLE = ele.isNode() ? DEFAULT_NODE_STYLE : DEFAULT_EDGE_STYLE;

--- a/test/cx-conversion-test.js
+++ b/test/cx-conversion-test.js
@@ -12,6 +12,8 @@ PouchDB.plugin(PouchDBMemoryAdapter);
 
 import { registerCytoscapeExtensions } from '../src/model/cy-extensions';
 import { getCXType } from '../src/model/import-export/cx/cy-converter';
+import { getCXValue } from '../src/model/import-export/cx/cx-export-visual-properties';
+import { STYLE_TYPE } from '../src/model/style';
 
 describe('CX Conversion', () => {
     before(() => {
@@ -68,6 +70,40 @@ describe('CX Conversion', () => {
 
     //   expect(expected[0]).to.deep.equal(actual[0]);
     // }).timeout(100000);
+
+    it('converts CE style values to CX style values', () => {
+      let tests = [
+          {
+            input: {
+              type: STYLE_TYPE.NUMBER,
+              value: 1
+            },
+            output: 1
+          },
+          {
+            input: {
+              type: STYLE_TYPE.STRING,
+              value: '1'
+            },
+            output: '1'
+          },
+          {
+            input: {
+              type: STYLE_TYPE.COLOR,
+              value: {
+                r: 100,
+                g: 100,
+                b: 100
+              },
+            },
+            output: '#646464'
+          }
+      ];
+
+      tests.forEach(({input, output}) => {
+        expect(getCXValue(input)).to.equal(output);
+      });
+    });
 
     it('converts networks from CE to CX', () => {
       let inputPath = './fixtures/cy-cx-conversion/input/';

--- a/test/fixtures/cy-cx-conversion/input/node-label-position.json
+++ b/test/fixtures/cy-cx-conversion/input/node-label-position.json
@@ -1,0 +1,146 @@
+{
+  "data": {
+    "id": "cy7be0c3fb-d255-486c-b524-7f1cdbbc8ccb",
+    "_styles": {
+      "node": {
+        "height": {
+          "type": "NUMBER",
+          "mapping": "DEPENDANT",
+          "value": {
+            "property": "width",
+            "multiplier": 1
+          },
+          "stringValue": "1"
+        },
+        "label": {
+          "type": "STRING",
+          "mapping": "PASSTHROUGH",
+          "value": {
+            "data": "attr3"
+          },
+          "stringValue": "data(attr3)"
+        },
+        "text-halign": {
+          "type": "STRING",
+          "mapping": "DISCRETE",
+          "value": {
+            "data": "attr3",
+            "defaultValue": "center",
+            "styleValues": {
+              "B": "right",
+              "C": "center",
+              "D": "left",
+              "E": "center"
+            }
+          },
+          "stringValue": "???"
+        },
+        "text-valign": {
+          "type": "STRING",
+          "mapping": "DISCRETE",
+          "value": {
+            "data": "attr3",
+            "defaultValue": "top",
+            "styleValues": {
+              "B": "center",
+              "C": "bottom",
+              "D": "center",
+              "E": "center"
+            }
+          },
+          "stringValue": "???"
+        }
+      }
+    },
+    "_bypasses": {
+      "db7ccc3b-8287-4ffc-aa66-27c1ba4ee8ab": {
+        "text-halign": {
+          "type": "STRING",
+          "mapping": "VALUE",
+          "value": "center",
+          "stringValue": "center"
+        },
+        "text-valign": {
+          "type": "STRING",
+          "mapping": "VALUE",
+          "value": "center",
+          "stringValue": "center"
+        }
+      }
+    }
+  },
+  "elements": [
+    {
+      "data": {
+        "attr1": 0.4200672403731871,
+        "attr2": 0.3222293131445766,
+        "attr3": "C",
+        "id": "0e0f70fb-31e0-47cf-9fa4-205f4345f9c1"
+      },
+      "position": {
+        "x": 105.00795906765208,
+        "y": 264.09835133598637
+      }
+    },
+    {
+      "data": {
+        "attr1": 0.35529479243795814,
+        "attr2": 0.49136968003280845,
+        "attr3": "B",
+        "id": "33a61c21-43e5-4665-991d-2601ce5ff9a3"
+      },
+      "position": {
+        "x": 212.05343945423536,
+        "y": 157.04718590108016
+      }
+    },
+    {
+      "data": {
+        "attr1": 0.5213051597523573,
+        "attr2": -0.43317134750821173,
+        "attr3": "A",
+        "id": "9d113f32-e44d-4725-ae96-3fec16127610"
+      },
+      "position": {
+        "x": 100.01193860147812,
+        "y": 156.03922683342807
+      }
+    },
+    {
+      "data": {
+        "attr1": 0.7963041882706137,
+        "attr2": -0.14159870630306282,
+        "attr3": "A",
+        "id": "db7ccc3b-8287-4ffc-aa66-27c1ba4ee8ab"
+      },
+      "position": {
+        "x": 338.1495167708926,
+        "y": 209.07049459920407
+      }
+    },
+    {
+      "data": {
+        "attr1": 0.8101005105352563,
+        "attr2": -0.7193936384089037,
+        "attr3": "D",
+        "id": "e4343314-8296-435a-8583-077357ba4a60"
+      },
+      "position": {
+        "x": 212.05173393973848,
+        "y": 267.0955088118249
+      }
+    },
+    {
+      "data": {
+        "attr1": 0.507517942272609,
+        "attr2": -0.6887171421929401,
+        "attr3": "E",
+        "id": "fa53b3c4-82aa-43b1-b678-3187a13d7244"
+      },
+      "position": {
+        "x": 146.01478112563956,
+        "y": 211.07447413303015
+      }
+    }
+  ]
+}

--- a/test/fixtures/cy-cx-conversion/output/continuous-mapping.json.cx
+++ b/test/fixtures/cy-cx-conversion/output/continuous-mapping.json.cx
@@ -182,26 +182,31 @@
             "NETWORK_BACKGROUND_COLOR": "#FFFFFF"
           },
           "node": {
-            "NODE_BACKGROUND_COLOR": "#888888",
-            "NODE_WIDTH": 30,
-            "NODE_BORDER_COLOR": "#888888",
-            "NODE_BORDER_WIDTH": 1,
             "NODE_SHAPE": "ellipse",
+            "NODE_BORDER_WIDTH": 1,
+            "NODE_BORDER_COLOR": "#888888",
             "NODE_LABEL_COLOR": "#111111",
             "NODE_LABEL_FONT_SIZE": 10
           },
           "edge": {
-            "EDGE_LINE_COLOR": "#888888",
-            "EDGE_LINE_WIDTH": 2,
-            "EDGE_SOURCE_ARROW_SHAPE": "none",
-            "EDGE_SOURCE_ARROW_COLOR": "#888888",
-            "EDGE_TARGET_ARROW_SHAPE": "none",
+            "EDGE_LINE_STYLE": "solid",
             "EDGE_TARGET_ARROW_COLOR": "#888888",
-            "EDGE_LINE_STYLE": "solid"
+            "EDGE_TARGET_ARROW_SHAPE": "none",
+            "EDGE_SOURCE_ARROW_COLOR": "#888888",
+            "EDGE_SOURCE_ARROW_SHAPE": "none",
+            "EDGE_LINE_WIDTH": 2,
+            "EDGE_LINE_COLOR": "#888888"
           }
         },
         "nodeMapping": {
-          "NODE_BACKGROUND_COLOR": {
+          "NODE_LABEL": {
+            "type": "PASSTHROUGH",
+            "definition": {
+              "attribute": "name",
+              "selector": "data(name)"
+            }
+          },
+          "NODE_HEIGHT": {
             "type": "CONTINUOUS",
             "definition": {
               "attribute": "attr2",
@@ -211,8 +216,8 @@
                   "includeMin": true,
                   "max": 0.5367898306456453,
                   "includeMax": true,
-                  "minVPValue": "#E6B3B3",
-                  "maxVPValue": "#993333"
+                  "minVPValue": 50,
+                  "maxVPValue": 10
                 }
               ]
             }
@@ -233,7 +238,7 @@
               ]
             }
           },
-          "NODE_HEIGHT": {
+          "NODE_BACKGROUND_COLOR": {
             "type": "CONTINUOUS",
             "definition": {
               "attribute": "attr2",
@@ -243,8 +248,8 @@
                   "includeMin": true,
                   "max": 0.5367898306456453,
                   "includeMax": true,
-                  "minVPValue": 50,
-                  "maxVPValue": 10
+                  "minVPValue": "#E6B3B3",
+                  "maxVPValue": "#993333"
                 }
               ]
             }

--- a/test/fixtures/cy-cx-conversion/output/continuous-mapping.json.cx
+++ b/test/fixtures/cy-cx-conversion/output/continuous-mapping.json.cx
@@ -174,10 +174,11 @@
             "NODE_SHAPE": "ellipse",
             "NODE_BORDER_WIDTH": 1,
             "NODE_BORDER_COLOR": "#888888",
+            "NODE_LABEL": "",
             "NODE_LABEL_POSITION": {
               "HORIZONTAL_ALIGN": "center",
               "HORIZONTAL_ANCHOR": "center",
-              "JUSTIFCATION": "center",
+              "JUSTIFICATION": "center",
               "MARGIN_X": 0,
               "MARGIN_Y": 0,
               "VERTICAL_ALIGN": "center",
@@ -197,13 +198,6 @@
           }
         },
         "nodeMapping": {
-          "NODE_LABEL": {
-            "type": "PASSTHROUGH",
-            "definition": {
-              "attribute": "name",
-              "selector": "data(name)"
-            }
-          },
           "NODE_HEIGHT": {
             "type": "CONTINUOUS",
             "definition": {

--- a/test/fixtures/cy-cx-conversion/output/discrete-mapping.json.cx
+++ b/test/fixtures/cy-cx-conversion/output/discrete-mapping.json.cx
@@ -152,22 +152,23 @@
             "NETWORK_BACKGROUND_COLOR": "#FFFFFF"
           },
           "node": {
-            "NODE_BACKGROUND_COLOR": "#888888",
-            "NODE_WIDTH": 30,
-            "NODE_BORDER_COLOR": "#888888",
-            "NODE_BORDER_WIDTH": 1,
             "NODE_SHAPE": "ellipse",
+            "NODE_BORDER_WIDTH": 1,
+            "NODE_BORDER_COLOR": "#888888",
+            "NODE_HEIGHT": 30,
+            "NODE_WIDTH": 30,
+            "NODE_BACKGROUND_COLOR": "#888888",
             "NODE_LABEL_COLOR": "#111111",
             "NODE_LABEL_FONT_SIZE": 10
           },
           "edge": {
-            "EDGE_LINE_COLOR": "#888888",
-            "EDGE_LINE_WIDTH": 2,
-            "EDGE_SOURCE_ARROW_SHAPE": "none",
-            "EDGE_SOURCE_ARROW_COLOR": "#888888",
-            "EDGE_TARGET_ARROW_SHAPE": "none",
+            "EDGE_LINE_STYLE": "solid",
             "EDGE_TARGET_ARROW_COLOR": "#888888",
-            "EDGE_LINE_STYLE": "solid"
+            "EDGE_TARGET_ARROW_SHAPE": "none",
+            "EDGE_SOURCE_ARROW_COLOR": "#888888",
+            "EDGE_SOURCE_ARROW_SHAPE": "none",
+            "EDGE_LINE_WIDTH": 2,
+            "EDGE_LINE_COLOR": "#888888"
           }
         },
         "nodeMapping": {
@@ -185,6 +186,13 @@
                   "vp": "triangle"
                 }
               ]
+            }
+          },
+          "NODE_LABEL": {
+            "type": "PASSTHROUGH",
+            "definition": {
+              "attribute": "name",
+              "selector": "data(name)"
             }
           }
         },

--- a/test/fixtures/cy-cx-conversion/output/discrete-mapping.json.cx
+++ b/test/fixtures/cy-cx-conversion/output/discrete-mapping.json.cx
@@ -54,16 +54,9 @@
           "version": {
             "d": "string",
             "v": ""
-          },
-          "cytoscapeExploreId": {
-            "d": "string",
-            "v": ""
           }
         },
         "nodes": {
-          "cytoscapeExploreId": {
-            "d": "string"
-          },
           "attr1": {
             "d": "double"
           },
@@ -75,9 +68,6 @@
           }
         },
         "edges": {
-          "cytoscapeExploreId": {
-            "d": "string"
-          },
           "attr1": {
             "d": "double"
           },
@@ -158,6 +148,15 @@
             "NODE_HEIGHT": 30,
             "NODE_WIDTH": 30,
             "NODE_BACKGROUND_COLOR": "#888888",
+            "NODE_LABEL_POSITION": {
+              "HORIZONTAL_ALIGN": "center",
+              "HORIZONTAL_ANCHOR": "center",
+              "JUSTIFCATION": "center",
+              "MARGIN_X": 0,
+              "MARGIN_Y": 0,
+              "VERTICAL_ALIGN": "center",
+              "VERTICAL_ANCHOR": "top"
+            },
             "NODE_LABEL_COLOR": "#111111",
             "NODE_LABEL_FONT_SIZE": 10
           },

--- a/test/fixtures/cy-cx-conversion/output/discrete-mapping.json.cx
+++ b/test/fixtures/cy-cx-conversion/output/discrete-mapping.json.cx
@@ -145,13 +145,14 @@
             "NODE_SHAPE": "ellipse",
             "NODE_BORDER_WIDTH": 1,
             "NODE_BORDER_COLOR": "#888888",
+            "NODE_LABEL": "",
             "NODE_HEIGHT": 30,
             "NODE_WIDTH": 30,
             "NODE_BACKGROUND_COLOR": "#888888",
             "NODE_LABEL_POSITION": {
               "HORIZONTAL_ALIGN": "center",
               "HORIZONTAL_ANCHOR": "center",
-              "JUSTIFCATION": "center",
+              "JUSTIFICATION": "center",
               "MARGIN_X": 0,
               "MARGIN_Y": 0,
               "VERTICAL_ALIGN": "center",
@@ -185,13 +186,6 @@
                   "vp": "triangle"
                 }
               ]
-            }
-          },
-          "NODE_LABEL": {
-            "type": "PASSTHROUGH",
-            "definition": {
-              "attribute": "name",
-              "selector": "data(name)"
             }
           }
         },

--- a/test/fixtures/cy-cx-conversion/output/general.json.cx
+++ b/test/fixtures/cy-cx-conversion/output/general.json.cx
@@ -202,44 +202,25 @@
             "NETWORK_BACKGROUND_COLOR": "#FFFFFF"
           },
           "node": {
-            "NODE_BACKGROUND_COLOR": "#6666CC",
-            "NODE_WIDTH": 30,
-            "NODE_BORDER_COLOR": "#888888",
-            "NODE_BORDER_WIDTH": 1,
             "NODE_SHAPE": "round-rectangle",
+            "NODE_BORDER_COLOR": "#888888",
+            "NODE_HEIGHT": 30,
+            "NODE_WIDTH": 30,
+            "NODE_BACKGROUND_COLOR": "#6666CC",
             "NODE_LABEL_COLOR": "#111111",
             "NODE_LABEL_FONT_SIZE": 10
           },
           "edge": {
-            "EDGE_LINE_COLOR": "#282828",
-            "EDGE_LINE_WIDTH": 2,
-            "EDGE_SOURCE_ARROW_SHAPE": "none",
-            "EDGE_SOURCE_ARROW_COLOR": "#282828",
-            "EDGE_TARGET_ARROW_SHAPE": "none",
+            "EDGE_LINE_STYLE": "solid",
             "EDGE_TARGET_ARROW_COLOR": "#282828",
-            "EDGE_LINE_STYLE": "solid"
+            "EDGE_TARGET_ARROW_SHAPE": "none",
+            "EDGE_SOURCE_ARROW_COLOR": "#282828",
+            "EDGE_SOURCE_ARROW_SHAPE": "none",
+            "EDGE_LINE_WIDTH": 2,
+            "EDGE_LINE_COLOR": "#282828"
           }
         },
         "nodeMapping": {
-          "NODE_LABEL": {
-            "type": "PASSTHROUGH",
-            "definition": {
-              "attribute": "attr3",
-              "selector": "data(attr3)"
-            }
-          },
-          "NODE_BORDER_COLOR": {
-            "type": "DISCRETE",
-            "definition": {
-              "attribute": "attr2",
-              "map": [
-                {
-                  "v": "-0.5406318800042764",
-                  "vp": "#40BF40"
-                }
-              ]
-            }
-          },
           "NODE_BORDER_WIDTH": {
             "type": "CONTINUOUS",
             "definition": {
@@ -254,6 +235,25 @@
                   "maxVPValue": 10
                 }
               ]
+            }
+          },
+          "NODE_BORDER_COLOR": {
+            "type": "DISCRETE",
+            "definition": {
+              "attribute": "attr2",
+              "map": [
+                {
+                  "v": "-0.5406318800042764",
+                  "vp": "#40BF40"
+                }
+              ]
+            }
+          },
+          "NODE_LABEL": {
+            "type": "PASSTHROUGH",
+            "definition": {
+              "attribute": "attr3",
+              "selector": "data(attr3)"
             }
           }
         },

--- a/test/fixtures/cy-cx-conversion/output/general.json.cx
+++ b/test/fixtures/cy-cx-conversion/output/general.json.cx
@@ -200,7 +200,7 @@
             "NODE_LABEL_POSITION": {
               "HORIZONTAL_ALIGN": "center",
               "HORIZONTAL_ANCHOR": "center",
-              "JUSTIFCATION": "center",
+              "JUSTIFICATION": "center",
               "MARGIN_X": 0,
               "MARGIN_Y": 0,
               "VERTICAL_ALIGN": "center",

--- a/test/fixtures/cy-cx-conversion/output/general.json.cx
+++ b/test/fixtures/cy-cx-conversion/output/general.json.cx
@@ -54,16 +54,9 @@
           "version": {
             "d": "string",
             "v": ""
-          },
-          "cytoscapeExploreId": {
-            "d": "string",
-            "v": ""
           }
         },
         "nodes": {
-          "cytoscapeExploreId": {
-            "d": "string"
-          },
           "attr1": {
             "d": "double"
           },
@@ -75,9 +68,6 @@
           }
         },
         "edges": {
-          "cytoscapeExploreId": {
-            "d": "string"
-          },
           "attr1": {
             "d": "double"
           },
@@ -207,6 +197,15 @@
             "NODE_HEIGHT": 30,
             "NODE_WIDTH": 30,
             "NODE_BACKGROUND_COLOR": "#6666CC",
+            "NODE_LABEL_POSITION": {
+              "HORIZONTAL_ALIGN": "center",
+              "HORIZONTAL_ANCHOR": "center",
+              "JUSTIFCATION": "center",
+              "MARGIN_X": 0,
+              "MARGIN_Y": 0,
+              "VERTICAL_ALIGN": "center",
+              "VERTICAL_ANCHOR": "top"
+            },
             "NODE_LABEL_COLOR": "#111111",
             "NODE_LABEL_FONT_SIZE": 10
           },

--- a/test/fixtures/cy-cx-conversion/output/node-label-position.json.cx
+++ b/test/fixtures/cy-cx-conversion/output/node-label-position.json.cx
@@ -14,7 +14,7 @@
         "name": "networkAttributes"
       },
       {
-        "elementCount": 8,
+        "elementCount": 6,
         "name": "nodes"
       },
       {
@@ -84,79 +84,63 @@
     "nodes": [
       {
         "id": 0,
-        "x": 113.71900738982694,
-        "y": 124.82024815254326,
+        "x": 105.00795906765208,
+        "y": 264.09835133598637,
         "v": {
-          "attr1": 0.1928849362777716,
-          "attr2": -0.006081190046709928,
+          "attr1": 0.4200672403731871,
+          "attr2": 0.3222293131445766,
           "attr3": "C"
         }
       },
       {
         "id": 1,
-        "x": 88.43318792847883,
-        "y": 105.48625647020447,
+        "x": 212.05343945423536,
+        "y": 157.04718590108016,
         "v": {
-          "attr1": 0.11486683622907101,
-          "attr2": 0.1864245173670933,
-          "attr3": "A"
+          "attr1": 0.35529479243795814,
+          "attr2": 0.49136968003280845,
+          "attr3": "B"
         }
       },
       {
         "id": 2,
-        "x": 49.14102922303876,
-        "y": 123.27112830529838,
+        "x": 100.01193860147812,
+        "y": 156.03922683342807,
         "v": {
-          "attr1": 0.9966428864639394,
-          "attr2": -0.8990573724886688,
+          "attr1": 0.5213051597523573,
+          "attr2": -0.43317134750821173,
           "attr3": "A"
         }
       },
       {
         "id": 3,
-        "x": 49.76143172891413,
-        "y": 85.84017711748443,
+        "x": 338.1495167708926,
+        "y": 209.07049459920407,
         "v": {
-          "attr1": 0.8926463638473991,
-          "attr2": 0.5367898306456453,
+          "attr1": 0.7963041882706137,
+          "attr2": -0.14159870630306282,
           "attr3": "A"
         }
       },
       {
         "id": 4,
-        "x": 238,
-        "y": 104,
+        "x": 212.05173393973848,
+        "y": 267.0955088118249,
         "v": {
-          "attr1": 0.49668477042977854,
-          "attr2": -0.9739520368538983,
-          "attr3": "A"
+          "attr1": 0.8101005105352563,
+          "attr2": -0.7193936384089037,
+          "attr3": "D"
         }
       },
       {
         "id": 5,
-        "x": 112.83568649291004,
-        "y": 77.36134287052106,
+        "x": 146.01478112563956,
+        "y": 211.07447413303015,
         "v": {
-          "attr1": 0.22087846290189672,
-          "attr2": -0.8450705501480567,
-          "attr3": "B"
+          "attr1": 0.507517942272609,
+          "attr2": -0.6887171421929401,
+          "attr3": "E"
         }
-      },
-      {
-        "id": 6,
-        "x": 151.92104436305831,
-        "y": 109.62227317604025,
-        "v": {
-          "attr1": 0.8251090523957909,
-          "attr2": 0.17543456935878954,
-          "attr3": "B"
-        }
-      },
-      {
-        "id": 7,
-        "x": 49.14102922303876,
-        "y": 98.76262349023277,
-        "v": {}
       }
     ]
   },
@@ -174,6 +158,9 @@
             "NODE_SHAPE": "ellipse",
             "NODE_BORDER_WIDTH": 1,
             "NODE_BORDER_COLOR": "#888888",
+            "NODE_HEIGHT": 30,
+            "NODE_WIDTH": 30,
+            "NODE_BACKGROUND_COLOR": "#888888",
             "NODE_LABEL_POSITION": {
               "HORIZONTAL_ALIGN": "center",
               "HORIZONTAL_ANCHOR": "center",
@@ -200,54 +187,62 @@
           "NODE_LABEL": {
             "type": "PASSTHROUGH",
             "definition": {
-              "attribute": "name",
-              "selector": "data(name)"
+              "attribute": "attr3",
+              "selector": "data(attr3)"
             }
           },
-          "NODE_HEIGHT": {
-            "type": "CONTINUOUS",
+          "NODE_LABEL_POSITION": {
+            "type": "DISCRETE",
             "definition": {
-              "attribute": "attr2",
+              "attribute": "attr3",
               "map": [
                 {
-                  "min": -0.9739520368538983,
-                  "includeMin": true,
-                  "max": 0.5367898306456453,
-                  "includeMax": true,
-                  "minVPValue": 50,
-                  "maxVPValue": 10
-                }
-              ]
-            }
-          },
-          "NODE_WIDTH": {
-            "type": "CONTINUOUS",
-            "definition": {
-              "attribute": "attr2",
-              "map": [
+                  "v": "B",
+                  "vp": {
+                    "HORIZONTAL_ALIGN": "center",
+                    "HORIZONTAL_ANCHOR": "right",
+                    "JUSTIFCATION": "center",
+                    "MARGIN_X": 0,
+                    "MARGIN_Y": 0,
+                    "VERTICAL_ALIGN": "center",
+                    "VERTICAL_ANCHOR": "center"
+                  }
+                },
                 {
-                  "min": -0.9739520368538983,
-                  "includeMin": true,
-                  "max": 0.5367898306456453,
-                  "includeMax": true,
-                  "minVPValue": 50,
-                  "maxVPValue": 10
-                }
-              ]
-            }
-          },
-          "NODE_BACKGROUND_COLOR": {
-            "type": "CONTINUOUS",
-            "definition": {
-              "attribute": "attr2",
-              "map": [
+                  "v": "C",
+                  "vp": {
+                    "HORIZONTAL_ALIGN": "center",
+                    "HORIZONTAL_ANCHOR": "center",
+                    "JUSTIFCATION": "center",
+                    "MARGIN_X": 0,
+                    "MARGIN_Y": 0,
+                    "VERTICAL_ALIGN": "center",
+                    "VERTICAL_ANCHOR": "bottom"
+                  }
+                },
                 {
-                  "min": -0.9739520368538983,
-                  "includeMin": true,
-                  "max": 0.5367898306456453,
-                  "includeMax": true,
-                  "minVPValue": "#E6B3B3",
-                  "maxVPValue": "#993333"
+                  "v": "D",
+                  "vp": {
+                    "HORIZONTAL_ALIGN": "center",
+                    "HORIZONTAL_ANCHOR": "left",
+                    "JUSTIFCATION": "center",
+                    "MARGIN_X": 0,
+                    "MARGIN_Y": 0,
+                    "VERTICAL_ALIGN": "center",
+                    "VERTICAL_ANCHOR": "center"
+                  }
+                },
+                {
+                  "v": "E",
+                  "vp": {
+                    "HORIZONTAL_ALIGN": "center",
+                    "HORIZONTAL_ANCHOR": "center",
+                    "JUSTIFCATION": "center",
+                    "MARGIN_X": 0,
+                    "MARGIN_Y": 0,
+                    "VERTICAL_ALIGN": "center",
+                    "VERTICAL_ANCHOR": "center"
+                  }
                 }
               ]
             }
@@ -260,9 +255,17 @@
   {
     "nodeBypasses": [
       {
-        "id": 4,
+        "id": 3,
         "v": {
-          "NODE_BACKGROUND_COLOR": "#339933"
+          "NODE_LABEL_POSITION": {
+            "HORIZONTAL_ALIGN": "center",
+            "HORIZONTAL_ANCHOR": "center",
+            "JUSTIFCATION": "center",
+            "MARGIN_X": 0,
+            "MARGIN_Y": 0,
+            "VERTICAL_ALIGN": "center",
+            "VERTICAL_ANCHOR": "center"
+          }
         }
       }
     ]

--- a/test/fixtures/cy-cx-conversion/output/node-label-position.json.cx
+++ b/test/fixtures/cy-cx-conversion/output/node-label-position.json.cx
@@ -164,7 +164,7 @@
             "NODE_LABEL_POSITION": {
               "HORIZONTAL_ALIGN": "center",
               "HORIZONTAL_ANCHOR": "center",
-              "JUSTIFCATION": "center",
+              "JUSTIFICATION": "center",
               "MARGIN_X": 0,
               "MARGIN_Y": 0,
               "VERTICAL_ALIGN": "center",
@@ -201,7 +201,7 @@
                   "vp": {
                     "HORIZONTAL_ALIGN": "center",
                     "HORIZONTAL_ANCHOR": "right",
-                    "JUSTIFCATION": "center",
+                    "JUSTIFICATION": "center",
                     "MARGIN_X": 0,
                     "MARGIN_Y": 0,
                     "VERTICAL_ALIGN": "center",
@@ -213,7 +213,7 @@
                   "vp": {
                     "HORIZONTAL_ALIGN": "center",
                     "HORIZONTAL_ANCHOR": "center",
-                    "JUSTIFCATION": "center",
+                    "JUSTIFICATION": "center",
                     "MARGIN_X": 0,
                     "MARGIN_Y": 0,
                     "VERTICAL_ALIGN": "center",
@@ -225,7 +225,7 @@
                   "vp": {
                     "HORIZONTAL_ALIGN": "center",
                     "HORIZONTAL_ANCHOR": "left",
-                    "JUSTIFCATION": "center",
+                    "JUSTIFICATION": "center",
                     "MARGIN_X": 0,
                     "MARGIN_Y": 0,
                     "VERTICAL_ALIGN": "center",
@@ -237,7 +237,7 @@
                   "vp": {
                     "HORIZONTAL_ALIGN": "center",
                     "HORIZONTAL_ANCHOR": "center",
-                    "JUSTIFCATION": "center",
+                    "JUSTIFICATION": "center",
                     "MARGIN_X": 0,
                     "MARGIN_Y": 0,
                     "VERTICAL_ALIGN": "center",
@@ -260,7 +260,7 @@
           "NODE_LABEL_POSITION": {
             "HORIZONTAL_ALIGN": "center",
             "HORIZONTAL_ANCHOR": "center",
-            "JUSTIFCATION": "center",
+            "JUSTIFICATION": "center",
             "MARGIN_X": 0,
             "MARGIN_Y": 0,
             "VERTICAL_ALIGN": "center",

--- a/test/fixtures/cy-cx-conversion/output/passthrough-mapping.json.cx
+++ b/test/fixtures/cy-cx-conversion/output/passthrough-mapping.json.cx
@@ -54,16 +54,9 @@
           "version": {
             "d": "string",
             "v": ""
-          },
-          "cytoscapeExploreId": {
-            "d": "string",
-            "v": ""
           }
         },
         "nodes": {
-          "cytoscapeExploreId": {
-            "d": "string"
-          },
           "attr1": {
             "d": "double"
           },
@@ -74,11 +67,7 @@
             "d": "string"
           }
         },
-        "edges": {
-          "cytoscapeExploreId": {
-            "d": "string"
-          }
-        }
+        "edges": {}
       }
     ]
   },
@@ -126,23 +115,32 @@
             "NETWORK_BACKGROUND_COLOR": "#FFFFFF"
           },
           "node": {
-            "NODE_BACKGROUND_COLOR": "#888888",
-            "NODE_WIDTH": 30,
-            "NODE_BORDER_COLOR": "#888888",
-            "NODE_BORDER_WIDTH": 1,
             "NODE_SHAPE": "ellipse",
+            "NODE_BORDER_WIDTH": 1,
+            "NODE_BORDER_COLOR": "#888888",
+            "NODE_HEIGHT": 30,
+            "NODE_WIDTH": 30,
+            "NODE_BACKGROUND_COLOR": "#888888",
+            "NODE_LABEL_POSITION": {
+              "HORIZONTAL_ALIGN": "center",
+              "HORIZONTAL_ANCHOR": "center",
+              "JUSTIFCATION": "center",
+              "MARGIN_X": 0,
+              "MARGIN_Y": 0,
+              "VERTICAL_ALIGN": "center",
+              "VERTICAL_ANCHOR": "top"
+            },
             "NODE_LABEL_COLOR": "#111111",
-            "NODE_LABEL_FONT_SIZE": 10,
-            "NODE_HEIGHT": 30
+            "NODE_LABEL_FONT_SIZE": 10
           },
           "edge": {
-            "EDGE_LINE_COLOR": "#888888",
-            "EDGE_LINE_WIDTH": 2,
-            "EDGE_SOURCE_ARROW_SHAPE": "none",
-            "EDGE_SOURCE_ARROW_COLOR": "#888888",
-            "EDGE_TARGET_ARROW_SHAPE": "none",
+            "EDGE_LINE_STYLE": "solid",
             "EDGE_TARGET_ARROW_COLOR": "#888888",
-            "EDGE_LINE_STYLE": "solid"
+            "EDGE_TARGET_ARROW_SHAPE": "none",
+            "EDGE_SOURCE_ARROW_COLOR": "#888888",
+            "EDGE_SOURCE_ARROW_SHAPE": "none",
+            "EDGE_LINE_WIDTH": 2,
+            "EDGE_LINE_COLOR": "#888888"
           }
         },
         "nodeMapping": {

--- a/test/fixtures/cy-cx-conversion/output/passthrough-mapping.json.cx
+++ b/test/fixtures/cy-cx-conversion/output/passthrough-mapping.json.cx
@@ -124,7 +124,7 @@
             "NODE_LABEL_POSITION": {
               "HORIZONTAL_ALIGN": "center",
               "HORIZONTAL_ANCHOR": "center",
-              "JUSTIFCATION": "center",
+              "JUSTIFICATION": "center",
               "MARGIN_X": 0,
               "MARGIN_Y": 0,
               "VERTICAL_ALIGN": "center",


### PR DESCRIPTION
**General information**

Associated issues: #57, #59

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**
This PR adds support for node label position properties when exporting networks to CX.  The previous approach was not designed for nested CX properties so I had to redesign the exporter taking into account that a property could be nested.

I use a lookup table for all the CX properties we want to support.  Most CX properties use the same conversion function but the table optionally contains an override conversion function for nested properties.  

This approach iterates over a hardcoded table of supported CX properties instead of iterating through cytoscape.js style snapshots.  This should prevent things from breaking less often when new changes are made to the style model.