### PR TITLE
Add custom scroll bar support

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -7,6 +7,7 @@ import { Router } from './router';
 import { Chart } from 'chart.js';
 import annotationPlugin from 'chartjs-plugin-annotation';
 import { registerCytoscapeExtensions } from '../model/cy-extensions';
+import { fixOldFashionedScrollStyle } from './scroll';
 
 PouchDB.plugin(PouchDBMemoryAdapter);
 
@@ -27,3 +28,5 @@ ReactDOM.render(
   <Router/>,
   div
 );
+
+fixOldFashionedScrollStyle();

--- a/src/client/scroll.js
+++ b/src/client/scroll.js
@@ -1,0 +1,31 @@
+function getScrollBarWidth () {
+  var inner = document.createElement('p');
+  inner.style.width = "100%";
+  inner.style.height = "200px";
+
+  var outer = document.createElement('div');
+  outer.style.position = "absolute";
+  outer.style.top = "0px";
+  outer.style.left = "0px";
+  outer.style.visibility = "hidden";
+  outer.style.width = "200px";
+  outer.style.height = "150px";
+  outer.style.overflow = "hidden";
+  outer.appendChild (inner);
+
+  document.body.appendChild (outer);
+  var w1 = inner.offsetWidth;
+  outer.style.overflow = 'scroll';
+  var w2 = inner.offsetWidth;
+  if (w1 == w2) w2 = outer.clientWidth;
+
+  document.body.removeChild (outer);
+
+  return (w1 - w2);
+}
+
+export function fixOldFashionedScrollStyle() {
+  if (getScrollBarWidth() !== 0) {
+    document.body.classList.add('old-fashioned-scrollbars');
+  }
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4,3 +4,7 @@
   width: 100%;
   overflow: hidden;
 }
+
+.cy {
+  background: #fff;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -7,3 +7,4 @@
 @import "./custom-icons.css";
 @import "./app.css";
 @import "./components/index.css";
+@import "./scrolling.css";

--- a/src/styles/scrolling.css
+++ b/src/styles/scrolling.css
@@ -1,0 +1,25 @@
+.old-fashioned-scrollbars ::-webkit-scrollbar {
+  width: 14px;
+  height: 18px;
+}
+
+.old-fashioned-scrollbars ::-webkit-scrollbar-thumb {
+  min-height: 24px;
+  border: 4px solid rgba(0, 0, 0, 0);
+  background-clip: padding-box;
+  background-color: rgba(0, 0, 0, 0.5);
+  border-radius: 7px;
+  box-shadow:
+    inset -1px -1px 0 rgba(255, 255, 255, 0.05),
+    inset 1px 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.old-fashioned-scrollbars ::-webkit-scrollbar-button {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+.old-fashioned-scrollbars ::-webkit-scrollbar-corner {
+  background-color: transparent;
+}


### PR DESCRIPTION
**General information**

Associated issues:

- #106
- https://github.com/cytoscape/cytoscape-explore/discussions/99#discussioncomment-1690075

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix. -- N/A
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

If the user has set the preference to show inline scrollbars all the time in the Mac Preferences app, then we show an inline scrollbar styled to match our app.

If the user has the default preference (e.g. iOS scrollbars, modern scrollbars on Mac, GNOME, etc.), then the native scrollbars are used since modern scrollbars already look fine -- and native scrollbars are generally preferable where possible, in my opinion.

When the user has the default system preference for modern scrollbars:

https://user-images.githubusercontent.com/989043/143481052-bbc06780-476b-415e-b452-faf1e88a386d.mp4

When the user has 'always show scrollbars' as the system preference:


https://user-images.githubusercontent.com/989043/143481133-f5ca5870-b830-4130-ba01-786603d088d0.mp4


