### PR TITLE
Fix: Secret not created for new doc when CouchDB auth is enabled

### DIFF
--- a/src/server/routes/api/document.js
+++ b/src/server/routes/api/document.js
@@ -48,7 +48,7 @@ const makeNetworkId = () => 'cy' + uuid();
 };
 
 const setSecret = async (id, secret) => {
-  let options;
+  let options = {};
 
     if (USE_COUCH_AUTH) {
       options.auth = {


### PR DESCRIPTION
**General information**

Associated issues: #107 

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix. -- N/A
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- This is a one-liner.  Without it, couch-auth-enabled instances can't create secrets properly.
- This only affects instances where CouchDB auth is enabled.  By default, local instances have auth off.
- Found by testing https://dev.ce.baderlab.org/demo
  - That URL works, because I jury-rigged the secret for the demo
  - New docs fail