### PR TITLE
Feature/slide out side panel

### DIFF
--- a/src/client/components/layout/layout-panel.js
+++ b/src/client/components/layout/layout-panel.js
@@ -77,8 +77,6 @@ export class LayoutPanel extends Component {
 
     return (
       <div className="layout-panel">
-        <div className="tool-panel-heading">Layout</div>
-
         <div position="relative" color="default">
           <Tabs
             value={value}

--- a/src/client/components/network-editor/index.js
+++ b/src/client/components/network-editor/index.js
@@ -185,6 +185,7 @@ export class NetworkEditor extends Component {
 
   render() {
     const { controller } = this;
+    const setOpen = open => this.setState({ rightPanelOpen: open });
 
     const panelStyleOverrides = {};
     if(this.state.rightPanelOpen) {
@@ -197,15 +198,13 @@ export class NetworkEditor extends Component {
         <div className="network-editor">
           <Header controller={controller} />
           <div className="network-editor-content">
-            <div className="cy" style={panelStyleOverrides}>
-              <div id="cy" />
-              <NetworkBackground controller={controller} />
-            </div>
+              <div className="cy" style={panelStyleOverrides}>
+                <div id="cy" />
+                <NetworkBackground controller={controller} />
+              </div>
             <ToolPanel 
               controller={controller} 
-              onSetOpen={open => {
-                this.setState({ rightPanelOpen: open });
-              }}
+              onSetOpen={setOpen}
             />
           </div>
         </div>

--- a/src/client/components/network-editor/index.js
+++ b/src/client/components/network-editor/index.js
@@ -42,6 +42,12 @@ export class NetworkEditor extends Component {
       window.controller = this.controller;
     }
 
+    this.state = {
+      rightPanelOpen: false,
+      // can add more panels here
+    };
+
+
     this.cy.style().fromJson([
       {
         selector: 'node',
@@ -180,17 +186,27 @@ export class NetworkEditor extends Component {
   render() {
     const { controller } = this;
 
+    const panelStyleOverride = {};
+    if(this.state.rightPanelOpen) {
+      panelStyleOverride.right = '350px';
+    }
+
     return (
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <div className="network-editor">
           <Header controller={controller} />
           <div className="network-editor-content">
-            <div className="cy">
+            <div className="cy" style={panelStyleOverride}>
               <div id="cy" />
               <NetworkBackground controller={controller} />
             </div>
-            <ToolPanel controller={controller} />
+            <ToolPanel 
+              controller={controller} 
+              onSetOpen={open => {
+                this.setState({ rightPanelOpen: open });
+              }}
+            />
           </div>
         </div>
       </ThemeProvider>

--- a/src/client/components/network-editor/index.js
+++ b/src/client/components/network-editor/index.js
@@ -186,9 +186,9 @@ export class NetworkEditor extends Component {
   render() {
     const { controller } = this;
 
-    const panelStyleOverride = {};
+    const panelStyleOverrides = {};
     if(this.state.rightPanelOpen) {
-      panelStyleOverride.right = '350px';
+      panelStyleOverrides.right = '300px';
     }
 
     return (
@@ -197,7 +197,7 @@ export class NetworkEditor extends Component {
         <div className="network-editor">
           <Header controller={controller} />
           <div className="network-editor-content">
-            <div className="cy" style={panelStyleOverride}>
+            <div className="cy" style={panelStyleOverrides}>
               <div id="cy" />
               <NetworkBackground controller={controller} />
             </div>

--- a/src/client/components/network-editor/tool-panel.js
+++ b/src/client/components/network-editor/tool-panel.js
@@ -9,18 +9,15 @@ import { StyleSection, StylePanel, OpacityStylePicker } from '../style/style-pic
 import { ColorStylePicker, ShapeStylePicker, SizeStylePicker, TextStylePicker } from '../style/style-picker';
 import { NodeSizeStyleSection, NodeLabelPositionStylePicker } from '../style/style-picker';
 import { LayoutPanel } from '../layout/layout-panel';
-
-
+import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
 
 function SidePanel({ title, onClose, children }) {
   return <div>
     <div className="tool-panel-heading">
       { title || "Panel" }
-      {/* <Tooltip arrow placement="left" title="Close Panel"> */}
-        <IconButton size="small" onClick={onClose}>
-          <i className="material-icons">keyboard_arrow_right</i>
-        </IconButton>
-      {/* </Tooltip> */}
+      <IconButton size="small" onClick={onClose}>
+        <KeyboardArrowRightIcon />
+      </IconButton>
     </div>
     <div>
       { children }
@@ -85,7 +82,7 @@ export class ToolPanel extends Component {
         anchor='right' 
         open={this.state.panelOpen} 
         style={{ zIndex: -1 }} // MKTODO Is there a better way to do this?
-        SlideProps={{ // Notify the network editor after the slide animation completes.
+        SlideProps={{ // Notify the network editor *after* the slide animation completes.
           onEntered: notifyOpen,
           onExit: notifyClose
         }}>

--- a/src/client/components/network-editor/tool-panel.js
+++ b/src/client/components/network-editor/tool-panel.js
@@ -3,6 +3,7 @@ import EventEmitterProxy from '../../../model/event-emitter-proxy';
 import PropTypes from 'prop-types';
 import { NetworkEditorController } from './controller';
 import Tooltip from '@material-ui/core/Tooltip';
+import { Drawer } from '@material-ui/core';
 import { IconButton, Divider, Box } from '@material-ui/core';
 import { StyleSection, StylePanel, OpacityStylePicker } from '../style/style-picker'; 
 import { ColorStylePicker, ShapeStylePicker, SizeStylePicker, TextStylePicker } from '../style/style-picker';
@@ -16,7 +17,8 @@ export class ToolPanel extends Component {
     super(props);
     this.busProxy = new EventEmitterProxy(this.props.controller.bus);
     this.state = {
-      toolRender: () => <div></div>
+      toolRender: () => <div></div>,
+      panelOpen: false,
     };
   }
 
@@ -33,9 +35,18 @@ export class ToolPanel extends Component {
     const { controller } = this.props;
     const { toolRender, tool } = this.state;
 
+    const openPanel = open => {
+      this.setState({ panelOpen: open });
+      this.props && this.props.onSetOpen(open);
+    };
+
     const ToolButton = ({ icon, title, tool, onClick = (() => {}), render = (() => <div></div>) }) => {
         const color = this.state.tool === tool ? 'primary' : 'inherit';
-        const buttonOnClick = () => { onClick(); this.setState({ tool, toolRender: render }); };
+        const buttonOnClick = () => { 
+          onClick(); 
+          this.setState({ tool, toolRender: render });
+          openPanel(true);
+        };
         
         return <Tooltip arrow placement="left" title={title}>
           <IconButton size="small" color={color} onClick={buttonOnClick}>
@@ -44,13 +55,21 @@ export class ToolPanel extends Component {
         </Tooltip>;
     };
 
+    const CollapseButton = () =>
+      <IconButton size="small" onClick={() => openPanel(false)}>
+        <i className="material-icons">keyboard_arrow_right</i>
+      </IconButton>;
 
-    return (<div className={"tool-panel " + (tool ? "tool-panel-has-tool" : "tool-panel-no-tool")}>
-      <Box className="tool-panel-content">
-        <div className="tool-panel-wrapper" bgcolor="background.paper">
-          { toolRender() }
+
+    return (<div className="tool-panel">
+      <Drawer variant='persistent' anchor='right' open={this.state.panelOpen} style={{ zIndex: -1 }}>
+        <div style={{ height: '60px'}} />
+        <div style={{ marginRight:'52px', width:'300px' }}>
+          <div className="tool-panel-wrapper" bgcolor="background.paper">
+            { toolRender() }
+          </div>
         </div>
-      </Box>
+      </Drawer>
 
       <Box className="tool-panel-buttons" bgcolor="background.paper" color="secondary.main">
 
@@ -71,7 +90,8 @@ export class ToolPanel extends Component {
             <StylePanel 
               title="Node Body"
               selector="node"
-              controller={controller}>
+              controller={controller}
+              extra={<CollapseButton />}>
               <StyleSection title="Color">
                 <ColorStylePicker
                   controller={controller}
@@ -242,7 +262,8 @@ export class ToolPanel extends Component {
 }
 
 ToolPanel.propTypes = {
-  controller: PropTypes.instanceOf(NetworkEditorController)
+  controller: PropTypes.instanceOf(NetworkEditorController),
+  onSetOpen: PropTypes.func,
 };
 
 export default ToolPanel;

--- a/src/client/components/network-editor/tool-panel.js
+++ b/src/client/components/network-editor/tool-panel.js
@@ -16,11 +16,11 @@ function SidePanel({ title, onClose, children }) {
   return <div>
     <div className="tool-panel-heading">
       { title || "Panel" }
-      <Tooltip arrow placement="left" title="Close Panel">
+      {/* <Tooltip arrow placement="left" title="Close Panel"> */}
         <IconButton size="small" onClick={onClose}>
           <i className="material-icons">keyboard_arrow_right</i>
         </IconButton>
-      </Tooltip>
+      {/* </Tooltip> */}
     </div>
     <div>
       { children }
@@ -56,15 +56,13 @@ export class ToolPanel extends Component {
 
   render(){
     const { controller } = this.props;
-    const { toolRender, tool } = this.state;
+    const { toolRender } = this.state;
 
-    const togglePanel = open => {
-      this.setState({ panelOpen: open });
-      this.props.onSetOpen && this.props.onSetOpen(open);
-    };
-    const openPanel  = () => togglePanel(true);
-    const closePanel = () => togglePanel(false);
-
+    const openPanel  = () => this.setState({ panelOpen: true });
+    const closePanel = () => this.setState({ panelOpen: false });
+    const notifyOpen  = () => this.props.onSetOpen(true);
+    const notifyClose = () => this.props.onSetOpen(false);
+      
     const ToolButton = ({ icon, title, tool, onClick = (() => {}), render = (() => <div></div>) }) => {
         const color = this.state.tool === tool ? 'primary' : 'inherit';
         const buttonOnClick = () => { 
@@ -82,7 +80,15 @@ export class ToolPanel extends Component {
 
 
     return (<div className="tool-panel">
-      <Drawer variant='persistent' anchor='right' open={this.state.panelOpen} style={{ zIndex: -1 }}>
+      <Drawer 
+        variant='persistent' 
+        anchor='right' 
+        open={this.state.panelOpen} 
+        style={{ zIndex: -1 }} // MKTODO Is there a better way to do this?
+        SlideProps={{ // Notify the network editor after the slide animation completes.
+          onEntered: notifyOpen,
+          onExit: notifyClose
+        }}>
         <div className="tool-panel-wrapper" bgcolor="background.paper">
           { toolRender() }
         </div>
@@ -279,6 +285,9 @@ export class ToolPanel extends Component {
 ToolPanel.propTypes = {
   controller: PropTypes.instanceOf(NetworkEditorController),
   onSetOpen: PropTypes.func,
+};
+ToolPanel.defaultProps ={
+  onSetOpen: () => null
 };
 
 export default ToolPanel;

--- a/src/client/components/network-editor/tool-panel.js
+++ b/src/client/components/network-editor/tool-panel.js
@@ -12,6 +12,29 @@ import { LayoutPanel } from '../layout/layout-panel';
 
 
 
+function SidePanel({ title, onClose, children }) {
+  return <div>
+    <div className="tool-panel-heading">
+      { title || "Panel" }
+      <Tooltip arrow placement="left" title="Close Panel">
+        <IconButton size="small" onClick={onClose}>
+          <i className="material-icons">keyboard_arrow_right</i>
+        </IconButton>
+      </Tooltip>
+    </div>
+    <div>
+      { children }
+    </div>
+  </div>;
+}
+SidePanel.propTypes = {
+  title: PropTypes.string,
+  children: PropTypes.any,
+  onClose: PropTypes.func,
+};
+
+
+
 export class ToolPanel extends Component {
   constructor(props){
     super(props);
@@ -35,17 +58,19 @@ export class ToolPanel extends Component {
     const { controller } = this.props;
     const { toolRender, tool } = this.state;
 
-    const openPanel = open => {
+    const togglePanel = open => {
       this.setState({ panelOpen: open });
-      this.props && this.props.onSetOpen(open);
+      this.props.onSetOpen && this.props.onSetOpen(open);
     };
+    const openPanel  = () => togglePanel(true);
+    const closePanel = () => togglePanel(false);
 
     const ToolButton = ({ icon, title, tool, onClick = (() => {}), render = (() => <div></div>) }) => {
         const color = this.state.tool === tool ? 'primary' : 'inherit';
         const buttonOnClick = () => { 
           onClick(); 
           this.setState({ tool, toolRender: render });
-          openPanel(true);
+          openPanel();
         };
         
         return <Tooltip arrow placement="left" title={title}>
@@ -55,29 +80,25 @@ export class ToolPanel extends Component {
         </Tooltip>;
     };
 
-    const CollapseButton = () =>
-      <IconButton size="small" onClick={() => openPanel(false)}>
-        <i className="material-icons">keyboard_arrow_right</i>
-      </IconButton>;
-
 
     return (<div className="tool-panel">
       <Drawer variant='persistent' anchor='right' open={this.state.panelOpen} style={{ zIndex: -1 }}>
-        <div style={{ height: '60px'}} />
-        <div style={{ marginRight:'52px', width:'300px' }}>
-          <div className="tool-panel-wrapper" bgcolor="background.paper">
-            { toolRender() }
-          </div>
+        <div className="tool-panel-wrapper" bgcolor="background.paper">
+          { toolRender() }
         </div>
       </Drawer>
 
       <Box className="tool-panel-buttons" bgcolor="background.paper" color="secondary.main">
 
         <ToolButton 
-          title="Layout" 
-          tool="layout" 
+          title="Layout"
+          tool="layout"
           icon="bolt" // bubble_chart"  "scatter_plot"  "grain"
-          render={() => <LayoutPanel controller={controller} />}>
+          render={() =>
+            <SidePanel title="Layout" onClose={closePanel}>
+              <LayoutPanel controller={controller} />
+            </SidePanel>
+          }>
         </ToolButton>
         
         <Divider />
@@ -86,31 +107,29 @@ export class ToolPanel extends Component {
           title="Node Body" 
           icon="lens"
           tool="node_body"
-          render={() => 
-            <StylePanel 
-              title="Node Body"
-              selector="node"
-              controller={controller}
-              extra={<CollapseButton />}>
-              <StyleSection title="Color">
-                <ColorStylePicker
+          render={() =>
+            <SidePanel title="Node Body" onClose={closePanel}>
+              <StylePanel selector="node" controller={controller}>
+                <StyleSection title="Color">
+                  <ColorStylePicker
+                    controller={controller}
+                    selector='node'
+                    styleProps={['background-color']}
+                  />
+                </StyleSection>
+                <StyleSection title="Shape">
+                  <ShapeStylePicker
+                    controller={controller}
+                    selector='node'
+                    styleProp='shape'
+                    variant='node'
+                  />
+                </StyleSection>
+                <NodeSizeStyleSection
                   controller={controller}
-                  selector='node'
-                  styleProps={['background-color']}
                 />
-              </StyleSection>
-              <StyleSection title="Shape">
-                <ShapeStylePicker
-                  controller={controller}
-                  selector='node'
-                  styleProp='shape'
-                  variant='node'
-                />
-              </StyleSection>
-              <NodeSizeStyleSection
-                controller={controller}
-              />
-            </StylePanel>
+              </StylePanel>
+            </SidePanel>
           }
         />
 
@@ -119,26 +138,25 @@ export class ToolPanel extends Component {
           icon="trip_origin"
           tool="node_border"
           render={() => 
-            <StylePanel 
-              title="Node Border"
-              selector="node"
-              controller={controller}>
-              <StyleSection title="Color">
-                <ColorStylePicker
-                  controller={controller}
-                  selector='node'
-                  styleProps={['border-color']}
-                />
-              </StyleSection>
-              <StyleSection title="Width">
-                <SizeStylePicker
-                  controller={controller}
-                  selector='node'
-                  styleProps={['border-width']}
-                  variant='border'
-                />
-              </StyleSection>
-            </StylePanel>
+            <SidePanel title="Node Border" onClose={closePanel}>
+              <StylePanel selector="node" controller={controller}>
+                <StyleSection title="Color">
+                  <ColorStylePicker
+                    controller={controller}
+                    selector='node'
+                    styleProps={['border-color']}
+                  />
+                </StyleSection>
+                <StyleSection title="Width">
+                  <SizeStylePicker
+                    controller={controller}
+                    selector='node'
+                    styleProps={['border-width']}
+                    variant='border'
+                  />
+                </StyleSection>
+              </StylePanel>
+            </SidePanel>
           }
         />
 
@@ -146,39 +164,38 @@ export class ToolPanel extends Component {
           title="Node Label" 
           icon="text_format"
           tool="node_label"
-          render={() => 
-            <StylePanel 
-              title="Node Label"
-              selector="node"
-              controller={controller}>
-              <StyleSection title="Text">
-                <TextStylePicker
-                  controller={controller}
-                  selector='node'
-                  styleProp='label'
-                />
-              </StyleSection>
-              <StyleSection title="Color">
-                <ColorStylePicker
-                  controller={controller}
-                  selector='node'
-                  styleProps={['color']}
-                />
-              </StyleSection>
-              <StyleSection title="Size">
-                <SizeStylePicker
-                  controller={controller}
-                  selector='node'
-                  styleProps={['font-size']}
-                  variant='text'
-                />
-              </StyleSection>
-              <StyleSection title="Position">
-                <NodeLabelPositionStylePicker
-                  controller={controller}
-                />
-              </StyleSection>
-            </StylePanel>
+          render={() =>
+            <SidePanel title="Node Label" onClose={closePanel}>
+              <StylePanel selector="node" controller={controller}>
+                <StyleSection title="Text">
+                  <TextStylePicker
+                    controller={controller}
+                    selector='node'
+                    styleProp='label'
+                  />
+                </StyleSection>
+                <StyleSection title="Color">
+                  <ColorStylePicker
+                    controller={controller}
+                    selector='node'
+                    styleProps={['color']}
+                  />
+                </StyleSection>
+                <StyleSection title="Size">
+                  <SizeStylePicker
+                    controller={controller}
+                    selector='node'
+                    styleProps={['font-size']}
+                    variant='text'
+                  />
+                </StyleSection>
+                <StyleSection title="Position">
+                  <NodeLabelPositionStylePicker
+                    controller={controller}
+                  />
+                </StyleSection>
+              </StylePanel>
+            </SidePanel>
           }
         />
 
@@ -188,42 +205,41 @@ export class ToolPanel extends Component {
           title="Edge" 
           icon="remove"
           tool="edge"
-          render={() => 
-            <StylePanel 
-              title="Edge"
-              selector="edge"
-              controller={controller}>
-              <StyleSection title="Color">
-                <ColorStylePicker
-                  controller={controller}
-                  selector='edge'
-                  styleProps={['line-color', 'source-arrow-color', 'target-arrow-color']}
-                />
-              </StyleSection>
-              <StyleSection title="Opacity">
-                <OpacityStylePicker
-                  controller={controller}
-                  selector='edge'
-                  styleProp='opacity'
-                />
-              </StyleSection>
-              <StyleSection title="Width">
-                <SizeStylePicker
-                  controller={controller}
-                  selector='edge'
-                  styleProps={['width']}
-                  variant='line'
-                />
-              </StyleSection>
-              <StyleSection title="Line Style">
-                <ShapeStylePicker
-                  controller={controller}
-                  selector='edge'
-                  styleProp='line-style'
-                  variant='line'
-                />
-              </StyleSection>
-            </StylePanel>
+          render={() =>
+            <SidePanel title="Edge" onClose={closePanel}>
+              <StylePanel selector="edge" controller={controller}>
+                <StyleSection title="Color">
+                  <ColorStylePicker
+                    controller={controller}
+                    selector='edge'
+                    styleProps={['line-color', 'source-arrow-color', 'target-arrow-color']}
+                  />
+                </StyleSection>
+                <StyleSection title="Opacity">
+                  <OpacityStylePicker
+                    controller={controller}
+                    selector='edge'
+                    styleProp='opacity'
+                  />
+                </StyleSection>
+                <StyleSection title="Width">
+                  <SizeStylePicker
+                    controller={controller}
+                    selector='edge'
+                    styleProps={['width']}
+                    variant='line'
+                  />
+                </StyleSection>
+                <StyleSection title="Line Style">
+                  <ShapeStylePicker
+                    controller={controller}
+                    selector='edge'
+                    styleProp='line-style'
+                    variant='line'
+                  />
+                </StyleSection>
+              </StylePanel>
+            </SidePanel>
           }
         />
 
@@ -232,27 +248,26 @@ export class ToolPanel extends Component {
           icon="arrow_forward"
           tool="edge_arrows"
           render={() =>
-            <StylePanel 
-              title="Edge Arrows"
-              selector="edge"
-              controller={controller}>
-              <StyleSection title="Source Arrow">
-                <ShapeStylePicker
-                  controller={controller}
-                  selector='edge'
-                  styleProp='source-arrow-shape'
-                  variant='arrow'
-                />
-              </StyleSection>
-              <StyleSection title="Target Arrow">
-                <ShapeStylePicker
-                  controller={controller}
-                  selector='edge'
-                  styleProp='target-arrow-shape'
-                  variant='arrow'
-                />
-              </StyleSection>
-            </StylePanel>
+            <SidePanel title="Edge Arrows" onClose={closePanel}>
+              <StylePanel selector="edge" controller={controller}>
+                <StyleSection title="Source Arrow">
+                  <ShapeStylePicker
+                    controller={controller}
+                    selector='edge'
+                    styleProp='source-arrow-shape'
+                    variant='arrow'
+                  />
+                </StyleSection>
+                <StyleSection title="Target Arrow">
+                  <ShapeStylePicker
+                    controller={controller}
+                    selector='edge'
+                    styleProp='target-arrow-shape'
+                    variant='arrow'
+                  />
+                </StyleSection>
+              </StylePanel>
+            </SidePanel>
           }
         />
 

--- a/src/client/components/style/style-picker.js
+++ b/src/client/components/style/style-picker.js
@@ -47,10 +47,6 @@ export class StylePanel extends React.Component {
   render() {
     return (
       <div className="style-panel">
-        <div className="tool-panel-heading">
-          { this.props.title || "Style Panel" }
-          <div className="tool-panel-extra">{this.props.extra}</div>
-        </div>
         { this.state.numSelected > 0 
           ? <div style={{ textAlign: 'center' }}>{ this.getBypassMessage() }</div> 
           : null 
@@ -63,10 +59,8 @@ export class StylePanel extends React.Component {
   }
 }
 StylePanel.propTypes = {
-  title: PropTypes.string,
   children: PropTypes.any,
   selector: PropTypes.oneOf(['node', 'edge']),
-  extra: PropTypes.any,
   controller: PropTypes.instanceOf(NetworkEditorController),
 };
 

--- a/src/client/components/style/style-picker.js
+++ b/src/client/components/style/style-picker.js
@@ -49,6 +49,7 @@ export class StylePanel extends React.Component {
       <div className="style-panel">
         <div className="tool-panel-heading">
           { this.props.title || "Style Panel" }
+          <div className="tool-panel-extra">{this.props.extra}</div>
         </div>
         { this.state.numSelected > 0 
           ? <div style={{ textAlign: 'center' }}>{ this.getBypassMessage() }</div> 
@@ -65,6 +66,7 @@ StylePanel.propTypes = {
   title: PropTypes.string,
   children: PropTypes.any,
   selector: PropTypes.oneOf(['node', 'edge']),
+  extra: PropTypes.any,
   controller: PropTypes.instanceOf(NetworkEditorController),
 };
 

--- a/src/styles/components/network-editor/cy.css
+++ b/src/styles/components/network-editor/cy.css
@@ -1,7 +1,7 @@
 .cy {
   position: absolute;
   left: 0;
-  right: 300px;
+  right: 50px;
   top: 0;
   bottom: 0;
 }

--- a/src/styles/components/network-editor/tool-panel.css
+++ b/src/styles/components/network-editor/tool-panel.css
@@ -33,6 +33,9 @@
 }
 
 .tool-panel-wrapper {
+  margin-right: 52px;
+  margin-top: 60px;
+  width: 250px;
   padding: 0.5em;
 }
 
@@ -137,11 +140,6 @@
 .tool-panel-section-secondary-title {
   color: rgba(255, 255, 255, 0.7);
   margin: 0.666em;
-}
-
-.tool-panel-extra {
-  cursor: pointer;
-  /* transform: scale(0.666); */
 }
 
 .tool-panel-bottom-spacer {

--- a/src/styles/components/network-editor/tool-panel.css
+++ b/src/styles/components/network-editor/tool-panel.css
@@ -51,6 +51,9 @@
   margin-right: -0.5em;
   padding-left: 1em;
   padding-right: 1em;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 }
 
 .layout-panel .tool-panel-heading {


### PR DESCRIPTION
**General information**

Associated issues: #113

**Checklist**

Author:

- [ ] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

This PR adds the ability to expand/collapse the side panel.

- The behaviour is this... Clicking on any toolbar button opens the panel. The panel has a close button at the top that closes the panel. 
  - I thought this would be the simplest way to update the UI without adding extra clutter. I'm happy to change this behaviour if others think there is a better way.
- The material-ui Drawer component is used to contain the panel. 
- I used z-index and padding to place the panel beneath the side toolbar buttons. I'm not sure if there's a better way to do that. 
- The network area adjusts its size when the panel is opened. This is for two reasons: 1) don't need to render the area underneath the panel and 2) the "fit content" button respects the actual visible area of the network correctly when the panel is opened or closed.
- I added a SidePanel component which contains the panel title and the close button. All of the side panels (layout and styles) use this as a parent now.
- I didn't think too much about making the ToolPanel component reusable for a slide-up bottom panel. But it should be possible to refactor the component to support both vertical and horizontal placement.
