### PR TITLE
Excel Import now creates a new document from the imported data

### DIFF
--- a/src/client/components/network-import/excel-import-wizard.js
+++ b/src/client/components/network-import/excel-import-wizard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { NetworkEditorController } from '../network-editor/controller';
 import theme from '../../theme';
+import Cytoscape from 'cytoscape';
 import _ from 'lodash';
 import * as XLSX from "xlsx";
 import { mean, std } from 'mathjs';
@@ -210,20 +211,40 @@ class ExcelImportSubWizard extends React.Component {
 
   async handleFinish() {
     const { networkName, edgeData, nodeData } = this.state;
+
+    const data = { name: networkName };
     const elements = this.createCyElements(edgeData, nodeData);
 
-    if (elements && elements.length > 0) {
-      try {
-        this.controller.setNetwork(elements, { name: networkName });
-      } catch (e) {
-        console.log(e); // TODO Show error to user
-      }
+    // Create another Cytoscape instance, just so we can apply a layout
+    const cy = new Cytoscape();
+    cy.data(data);
+    cy.add(elements);
 
-      // TODO Apply preferred layout
-      this.controller.applyLayout(this.controller.layoutOptions.fcose);
-    }
+    // Apply grid layout (but first, calculate an adequate bounding box where nodes don't overlap)
+    const nc = cy.nodes().length;
+    const size = 50 * Math.round(Math.sqrt(nc));
+    const w = 1.25 * size;
+    const h = 0.75 * size;
+    cy.layout({ name: 'grid', boundingBox: { x1: 0, y1: 0, w, h } }).run();
+    
+    // Get the json data that should now include the new node positions
+    const json = cy.json(true);
+    cy.destroy(); // We can now destroy this Cytoscape instance
+
+    // Ask the server to import the json data
+    const res = await fetch( `/api/document/json`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(json),
+    });
+
+    // Navigate to the new document
+    const urls = await res.json();
 
     this.props.wizardCallbacks.closeWizard();
+    location.replace(`/document/${urls.id}/${urls.secret}`); 
   }
 
   createCyElements(edgeData, nodeData) {

--- a/src/client/components/network-import/excel-import-wizard.js
+++ b/src/client/components/network-import/excel-import-wizard.js
@@ -216,16 +216,12 @@ class ExcelImportSubWizard extends React.Component {
     const elements = this.createCyElements(edgeData, nodeData);
 
     // Create another Cytoscape instance, just so we can apply a layout
-    const cy = new Cytoscape();
+    const cy = new Cytoscape({ styleEnabled: true });
     cy.data(data);
     cy.add(elements);
 
-    // Apply grid layout (but first, calculate an adequate bounding box where nodes don't overlap)
-    const nc = cy.nodes().length;
-    const size = 50 * Math.round(Math.sqrt(nc));
-    const w = 1.25 * size;
-    const h = 0.75 * size;
-    cy.layout({ name: 'grid', boundingBox: { x1: 0, y1: 0, w, h } }).run();
+    // Apply grid layout
+    cy.layout({ name: 'grid', avoidOverlap: true }).run();
     
     // Get the json data that should now include the new node positions
     const json = cy.json(true);


### PR DESCRIPTION
This changes how a network is created when importing Excel files.

Associated issues: #78

**Checklist**

Author:

- [X] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- It now asks the server to create a new document from the passed json data, instead of just replacing the current network's elements and data.
- Another change is that the importer now applies the 'grid' layout (before sending the json to the server), whereas It used to apply 'fcose'.