### PR TITLE
usability fixes for ndex import

### DIFF
--- a/src/client/components/network-import/ndex-import-wizard.js
+++ b/src/client/components/network-import/ndex-import-wizard.js
@@ -324,13 +324,13 @@ export class NDExImportSubWizard extends React.Component {
   }
 
   renderNetworkList(ndexNetworkReults) {
-    const handleRadio = (selectedId) => {
+    const handleNetworkSelection = (selectedId) => {
       this.setState({ selectedId });
       this.updateButtons({ ...this.state, selectedId });
     };
     return (
       <TableContainer component={Paper}>
-        <Table size="medium" aria-label="network table">
+        <Table size="large" aria-label="network table">
           <TableHead>
             <TableRow>
               <TableCell></TableCell>
@@ -342,13 +342,12 @@ export class NDExImportSubWizard extends React.Component {
           </TableHead>
           <TableBody>
             { ndexNetworkReults.map(network => (
-              <TableRow key={network.externalId}>
+              <TableRow key={network.externalId} 
+                selected={this.state.selectedId === network.externalId}
+                onClick={() => handleNetworkSelection(network.externalId)}
+                className="ndex-import-network-entry"
+              >
                 <TableCell align="center">
-                <Radio
-                  checked={this.state.selectedId === network.externalId}
-                  onClick={() => handleRadio(network.externalId)}
-                  value={network.externalId}
-                />
                 </TableCell>
                 <TableCell component="th" scope="row">{network.name}</TableCell>
                 <TableCell align="right">{network.owner}</TableCell>

--- a/src/styles/components/index.css
+++ b/src/styles/components/index.css
@@ -1,5 +1,6 @@
 @import "./network-editor/index.css";
 @import "./style/index.css";
 @import "./network-export/index.css";
+@import "./network-import/index.css";
 @import "./tippy-overrides.css";
 @import "./mui-overrides.css";

--- a/src/styles/components/network-import/index.css
+++ b/src/styles/components/network-import/index.css
@@ -1,0 +1,3 @@
+.ndex-import-network-entry {
+    cursor: pointer;
+}


### PR DESCRIPTION
- edges column no longer cut off in the ndex results table view
- user can click anywhere on the table entry to select an item
- cursor pointer when user hovers over an item

**General information**

This PR tries to address usability issues where the user could only click the radio circle to select a network to import.


https://user-images.githubusercontent.com/2328291/151847688-acd12b63-1439-4411-8837-05b6ea6d3b00.mov


**Checklist**

Author:

- [ ] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.

