### PR TITLE
Use a single CouchDB document to hold a network's data

### DIFF
--- a/src/client/components/network-editor/network-analyser.js
+++ b/src/client/components/network-editor/network-analyser.js
@@ -57,10 +57,35 @@ export class NetworkAnalyser {
     }
   }
 
+  _clearCountCache() {
+    this._countCache = {};
+  }
+
+  _getCachedCount(selector) {
+    let eles = this._countCache[selector];
+
+    if (eles == null) {
+      eles = this._countCache[selector] = this.cy.collection().merge(this.cy.filter(selector))
+    }
+
+    return eles.length;
+  }
+
+  _addToCountCache(selector, ele) {
+    if (this._countCache && this._countCache[selector] != null) {
+      this._countCache[selector].merge(ele);
+    }
+  }
+
+  _rmFromCountCache(selector, ele) {
+    if (this._countCache && this._countCache[selector] != null) {
+      this._countCache[selector].unmerge(ele);
+    }
+  }
 
   getCount(selector, attrName, type) {
     if(!attrName) {
-      return this.cy.elements(selector).size();
+      return this._getCachedCount(selector);
     }
     const attrInfo = this.attributes[selector].get(attrName);
     if(attrInfo) {
@@ -109,6 +134,7 @@ export class NetworkAnalyser {
 
 
   _reset() {
+    this._clearCountCache();
     this.attributes = {
       node: new Map(),
       edge: new Map()
@@ -125,6 +151,8 @@ export class NetworkAnalyser {
   // TWo things: iterate over all known attributes
   // If a new attribute is found
   _addElement(selector, ele) {
+    this._addToCountCache(selector, ele);
+
     const map = this.attributes[selector];
     const data = ele.data();
     const first = map.size == 0; // is this the first node or edge to be processed?
@@ -174,6 +202,8 @@ export class NetworkAnalyser {
   }
 
   _removeElement(selector, ele) {
+    this._rmFromCountCache(selector, ele);
+
     const map = this.attributes[selector];
     const toRemove = [];
 

--- a/src/client/components/network-editor/network-analyser.js
+++ b/src/client/components/network-editor/network-analyser.js
@@ -65,7 +65,7 @@ export class NetworkAnalyser {
     let eles = this._countCache[selector];
 
     if (eles == null) {
-      eles = this._countCache[selector] = this.cy.collection().merge(this.cy.filter(selector))
+      eles = this._countCache[selector] = this.cy.collection().merge(this.cy.filter(selector));
     }
 
     return eles.length;

--- a/test/syncher-test.js
+++ b/test/syncher-test.js
@@ -15,13 +15,15 @@ const on = (evt, target) => new Promise(resolve => {
   target.on(evt, resolve);
 });
 
-describe('CytoscapeSyncher', () => {
+describe('CytoscapeSyncher', function() {
   let cy, syncher; // instances for simualted client1
   let cy2, syncher2; // instances for simulated client2
   let id = 'test'; // test network id
   let secret = 'secret';
   let defSyncInt;
   let expressServer, expressApp;
+
+  this.timeout(10000);
 
   before(async () => {
     const { server, app } = await import('../src/server');


### PR DESCRIPTION
**General information**

Associated issues:
- #111
- #122 
- #123 
- #103 (similar effect in stuttering, though different cause)

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- Three main things
  - Each in separate commit
  - See commit logs for more details 
  - (1) Set a long timeout for automated tests in case the runner is slow.  Should fix GH tasks.
  - (2) CytoscapeSyncher uses a single doc in the DB.  Uploads are deferred by debouncing (currently 3s).
  - (3) Fix for stuttering when receiving a remote update.  To reproduce (on commit 75032c99fe82b58cb9519a4f40a242153b20d36b or earlier):
    - Load GAL filtered
    - Open two tabs
    - Run a layout in tab 1
    - In tab 2, continuously zoom the network in and out until the remote update for the layout comes in
    - Note that the UI stutters:  It locks up for a bit.  Really annoying if you're in the middle of something

Details re. (3), for those interested:

This is why the stuttering is there.  The network analyser does a lot of calls to `getCount()` and that's really slow (over 1s of lockup).  It's a lot of O(n) network filter (`cy.filter()`) queries, and it probably adds up to at least O(n^2) in aggregate.

<img width="1316" alt="getCount-slow" src="https://user-images.githubusercontent.com/989043/151851731-07f2bbeb-ee7f-49a8-9a96-b06258ca3717.png">

By caching `getCount()`, it's a lot faster (< 20 ms).  It caches element sets, which is a bit more expensive than it could be (ints).  However, it's robust to unbalanced add/remove calls etc.  @mikekucera, I'm sure you could optimise this more than I did here, though this seemed like enough for now.

<img width="1316" alt="Screen Shot 2022-01-31 at 13 13 42" src="https://user-images.githubusercontent.com/989043/151851944-a029596f-66a2-42ee-9d06-92ba7b41ff5b.png">
