### PR TITLE
Feature/image export

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eventemitter3": "^3.1.2",
     "express": "^4.17.1",
     "express-http-proxy": "^1.6.2",
+    "file-saver": "^2.0.5",
     "fready": "^1.0.0",
     "gaussian": "^1.2.0",
     "http-proxy-middleware": "^0.19.1",

--- a/src/client/components/network-editor/share-button.js
+++ b/src/client/components/network-editor/share-button.js
@@ -5,7 +5,8 @@ import EmailIcon from '@material-ui/icons/Email';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 import ImageIcon from '@material-ui/icons/Image';
 import LandscapeIcon from '@material-ui/icons/Landscape';
-import { Button, ClickAwayListener, IconButton, Paper, Popover, TextField, Tooltip } from '@material-ui/core';
+import { Button, ClickAwayListener, IconButton, Popover, TextField, Tooltip } from '@material-ui/core';
+import { saveAs } from 'file-saver';
 import { NetworkEditorController } from './controller';
 
 export class ShareButton extends React.Component {
@@ -13,6 +14,7 @@ export class ShareButton extends React.Component {
   constructor(props) {
     super(props);
     this.url = window.location.href;
+    this.controller = props.controller;
     this.state = {
       popoverAnchorEl: null,
       tooltipOpen: false,
@@ -29,12 +31,12 @@ export class ShareButton extends React.Component {
     navigator.clipboard.writeText(this.url);
   }
 
-  handleExportImage(type) {
-    if(type === 'png') {
-      console.log("Export PNG!");
-    } else if(type === 'jpg') {
-      console.log("Export JPG!");
-    }
+  async handleExportImage(type ) {
+    if(type !== 'png' || type !== 'jpg')
+      return;
+    const { cy } = this.controller;
+    const blob = await cy[type]({ output:'blob-promise' });
+    saveAs(blob, 'cytoscape_explore.' + type);
   }
 
   handlePopoverOpen(target) {

--- a/src/client/components/network-editor/share-button.js
+++ b/src/client/components/network-editor/share-button.js
@@ -58,6 +58,7 @@ export class ShareButton extends React.Component {
 
     const blob = await cy[imageType]({ 
       output:'blob-promise',
+      bg: 'white',
       full: imageArea === ImageArea.FULL,
       scale: imageSize.scale,
     });

--- a/src/client/components/network-editor/share-button.js
+++ b/src/client/components/network-editor/share-button.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import ScreenShareIcon from '@material-ui/icons/ScreenShare';
 import EmailIcon from '@material-ui/icons/Email';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
+import ImageIcon from '@material-ui/icons/Image';
+import LandscapeIcon from '@material-ui/icons/Landscape';
 import { Button, ClickAwayListener, IconButton, Paper, Popover, TextField, Tooltip } from '@material-ui/core';
 import { NetworkEditorController } from './controller';
 
@@ -27,10 +29,37 @@ export class ShareButton extends React.Component {
     navigator.clipboard.writeText(this.url);
   }
 
+  handleExportImage(type) {
+    if(type === 'png') {
+      console.log("Export PNG!");
+    } else if(type === 'jpg') {
+      console.log("Export JPG!");
+    }
+  }
+
+  handlePopoverOpen(target) {
+    this.setState({ 
+      popoverAnchorEl: target, 
+      tooltipOpen: false 
+    });
+  }
+
+  handlePopoverClose() {
+    this.setState({ 
+      popoverAnchorEl: null, 
+      tooltipOpen: false 
+    });
+  }
+
+  handleTooltip(tooltipOpen) {
+    this.setState({ tooltipOpen });
+  }
+
   render() {
-    const handlePopoverOpen = event => this.setState({ popoverAnchorEl: event.currentTarget, tooltipOpen: false });
-    const handlePopoverClose = () => this.setState({ popoverAnchorEl: null, tooltipOpen: false });
-    const handleTooltip = open => this.setState({ tooltipOpen: open });
+    const SectionHeader = ({ icon, text }) => 
+      <div className='share-button-popover-heading'>
+        {icon} &nbsp; {text}
+      </div>;
 
     const IconShareButton = () => 
       <Tooltip arrow placement="bottom" title="Share">
@@ -44,27 +73,22 @@ export class ShareButton extends React.Component {
         Send by email
       </Button>;
 
-    const PopoverForm = () => 
+    const ShareLinkForm = () => 
       <div className='share-button-popover-content'>
-        <div className='share-button-popover-heading'>
-          <ScreenShareIcon/> &nbsp; Share link to network
-        </div>
+        <SectionHeader icon={<ScreenShareIcon/>} text="Share link to network" />
         <TextField defaultValue={this.url} variant="outlined" size="small" />
         <div className='share-button-popover-buttons'>
           <EmailButton/>
-          <ClickAwayListener onClickAway={() => handleTooltip(false)}>
+          <ClickAwayListener onClickAway={() => this.handleTooltip(false)}>
             <div>
-              <Tooltip arrow
+              <Tooltip arrow disableFocusListener disableHoverListener disableTouchListener
                 PopperProps={{ disablePortal: true }}
-                onClose={() => handleTooltip(false)}
+                onClose={() => this.handleTooltip(false)}
                 open={this.state.tooltipOpen}
-                disableFocusListener
-                disableHoverListener
-                disableTouchListener
                 placement="right"
                 title="Copied!"
               >
-                <Button startIcon={<FileCopyIcon />} onClick={() => { this.handleCopyToClipboard(); handleTooltip(true); }}> 
+                <Button startIcon={<FileCopyIcon />} onClick={() => { this.handleCopyToClipboard(); this.handleTooltip(true); }}> 
                   Copy to Clipboard
                 </Button>
               </Tooltip>
@@ -73,19 +97,36 @@ export class ShareButton extends React.Component {
         </div>
       </div>;
 
+    const ImageExportButton = ({ type }) =>
+      <Button startIcon={<ImageIcon />} onClick={() => this.handleExportImage(type)}>
+        Export { type === 'png' ? "PNG" : "JPEG" } Image
+      </Button>;
+
+    const ExportImageForm = () => 
+      <div className='share-button-popover-content'>
+        <SectionHeader icon={<LandscapeIcon/>} text="Export Image" />
+        <div className='share-button-popover-buttons'>
+          <ImageExportButton type='png' />
+          <ImageExportButton type='jpg' />
+        </div>
+      </div>; 
+
     return <div> 
       <div>
-        <span onClick={handlePopoverOpen}><IconShareButton/></span>
+        <span onClick={evt => this.handlePopoverOpen(evt.currentTarget)}>
+          <IconShareButton/>
+        </span>
       </div>
       <Popover
         className='share-button-popover'
         open={Boolean(this.state.popoverAnchorEl)}
         anchorEl={this.state.popoverAnchorEl}
-        onClose={handlePopoverClose}
+        onClose={() => this.handlePopoverClose()}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
         transformOrigin={{ vertical: 'top', horizontal: 'center' }}
       >
-        <PopoverForm />
+        <ShareLinkForm />
+        <ExportImageForm />
       </Popover>
     </div>;
   }

--- a/src/client/components/network-editor/share-button.js
+++ b/src/client/components/network-editor/share-button.js
@@ -5,7 +5,7 @@ import EmailIcon from '@material-ui/icons/Email';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 import ImageIcon from '@material-ui/icons/Image';
 import LandscapeIcon from '@material-ui/icons/Landscape';
-import { Button, ClickAwayListener, FormLabel, IconButton, Popover, TextField, Tooltip } from '@material-ui/core';
+import { Button, ClickAwayListener, FormLabel, Grid, IconButton, Popover, TextField, Tooltip } from '@material-ui/core';
 import { RadioGroup, Radio, FormControlLabel, FormControl } from '@material-ui/core';
 import { saveAs } from 'file-saver';
 import { NetworkEditorController } from './controller';
@@ -87,13 +87,6 @@ export class ShareButton extends React.Component {
     const SectionHeader = ({ icon, text }) => 
       <div className='share-button-popover-heading'> {icon} &nbsp; {text} </div>;
 
-    const IconShareButton = () => 
-      <Tooltip arrow placement="bottom" title="Share">
-        <IconButton size="small" color="inherit">
-          <ScreenShareIcon />
-        </IconButton>
-      </Tooltip>;
-
     const ShareLinkForm = () => 
       <div className='share-button-popover-content'>
         <SectionHeader icon={<ScreenShareIcon/>} text="Share link to network" />
@@ -120,46 +113,47 @@ export class ShareButton extends React.Component {
         </div>
       </div>;
 
-    const ImageRadio = ({ label, value, onClick }) =>
-      <FormControlLabel label={label} value={value} control={<Radio size='small' onClick={() => onClick(value)}/>} />;
-
     const ExportImageForm = () => {
       const handleType = imageType => this.setState({ imageType }); 
       const handleSize = imageSize => this.setState({ imageSize: ImageSize[imageSize] });
       const handleArea = imageArea => this.setState({ imageArea });
+      const ImageRadio = ({ label, value, onClick }) =>
+        <FormControlLabel label={label} value={value} control={<Radio size='small' onClick={() => onClick(value)}/>} />;
       // Note: For some reason the RadioGroup.onChange handler does not fire, using Radio.onClick instead.
       // May have something to do with this: https://github.com/mui/material-ui/issues/9336
       return <div className='share-button-popover-content'>
         <SectionHeader icon={<LandscapeIcon/>} text="Export Image" />
         <div style={{ paddingLeft:'10px' }}>
-          <div>
-            <FormControl>
-              <FormLabel>Format</FormLabel>
-              <RadioGroup row value={this.state.imageType}>
-                <ImageRadio label="PNG" value={ImageType.PNG} onClick={handleType} />
-                <ImageRadio label="JPG" value={ImageType.JPG} onClick={handleType} />
-              </RadioGroup>
-            </FormControl>
-          </div>
-          <div>
-            <FormControl>
-              <FormLabel>Size</FormLabel>
-              <RadioGroup row value={this.state.imageSize.value}>
-                <ImageRadio label="Small"  value={ImageSize.SMALL.value}  onClick={handleSize} />
-                <ImageRadio label="Medium" value={ImageSize.MEDIUM.value} onClick={handleSize} />
-                <ImageRadio label="Large"  value={ImageSize.LARGE.value}  onClick={handleSize} />
-              </RadioGroup>
-            </FormControl>
-          </div>
-          <div>
-            <FormControl>
-              <FormLabel>Area</FormLabel>
-              <RadioGroup row value={this.state.imageArea}>
-                <ImageRadio label="Visible Area"   value={ImageArea.VIEW} onClick={handleArea} />
-                <ImageRadio label="Entire Network" value={ImageArea.FULL} onClick={handleArea} />
-              </RadioGroup>
-            </FormControl>
-          </div>
+          <Grid container alignItems="flex-start" spacing={3}>
+            <Grid item>
+              <FormControl>
+                <FormLabel>Size</FormLabel>
+                <RadioGroup value={this.state.imageSize.value}>
+                  <ImageRadio label="Small"  value={ImageSize.SMALL.value}  onClick={handleSize} />
+                  <ImageRadio label="Medium" value={ImageSize.MEDIUM.value} onClick={handleSize} />
+                  <ImageRadio label="Large"  value={ImageSize.LARGE.value}  onClick={handleSize} />
+                </RadioGroup>
+              </FormControl>
+            </Grid>
+            <Grid item>
+              <FormControl>
+                <FormLabel>Format</FormLabel>
+                <RadioGroup value={this.state.imageType}>
+                  <ImageRadio label="PNG" value={ImageType.PNG} onClick={handleType} />
+                  <ImageRadio label="JPG" value={ImageType.JPG} onClick={handleType} />
+                </RadioGroup>
+              </FormControl>
+            </Grid>
+            <Grid item>
+              <FormControl>
+                <FormLabel>Area</FormLabel>
+                <RadioGroup  value={this.state.imageArea}>
+                  <ImageRadio label="Visible Area"   value={ImageArea.VIEW} onClick={handleArea} />
+                  <ImageRadio label="Entire Network" value={ImageArea.FULL} onClick={handleArea} />
+                </RadioGroup>
+              </FormControl>
+            </Grid>
+          </Grid>
         </div>
         <div className='share-button-popover-buttons'>
           <Button variant='outlined' startIcon={<ImageIcon />} onClick={() => this.handleExportImage()}>
@@ -172,7 +166,11 @@ export class ShareButton extends React.Component {
     return <div> 
       <div>
         <span onClick={evt => this.handlePopoverOpen(evt.currentTarget)}>
-          <IconShareButton/>
+          <Tooltip arrow placement="bottom" title="Share">
+            <IconButton size="small" color="inherit">
+              <ScreenShareIcon />
+            </IconButton>
+          </Tooltip>
         </span>
       </div>
       <Popover


### PR DESCRIPTION
**General information**

Associated issues: #110

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

Adds a section to the Share Button popup that allows the network to be exported to an image.
Options for image format (png/jpg), size (small/medium/large) and the area of the network.

<img width="826" alt="Screen Shot 2022-02-28 at 2 29 18 PM" src="https://user-images.githubusercontent.com/5350528/156046341-09de6bee-fe0b-4eff-ae44-c340f0fb42f6.png">

